### PR TITLE
Avoid pluginAPI null reference in IE

### DIFF
--- a/src/js/mediaelement.js
+++ b/src/js/mediaelement.js
@@ -627,12 +627,7 @@ height="' + height + '"></embed>';
 				// find the javascript bridge
 				switch (pluginMediaElement.pluginType) {
 					case "flash":
-						// magic
-						if (navigator.appName.indexOf("Microsoft") != -1) {
-							pluginMediaElement.pluginElement = pluginMediaElement.pluginApi = window[id];
-						} else {
-							pluginMediaElement.pluginElement = pluginMediaElement.pluginApi = document[id];
-						}
+						pluginMediaElement.pluginElement = pluginMediaElement.pluginApi = document.getElementById(id);
 						break;
 					case "silverlight":
 						pluginMediaElement.pluginElement = document.getElementById(pluginMediaElement.id);


### PR DESCRIPTION
I've encountered an error in IE where the pluginAPI property was empty, and so the video couldn't be played. Couldn't see a rationale for using window[] in place of getElementById(), so tried that and it fixes the problem. 
