### PR TITLE
Fixing version detection for Flash 10

### DIFF
--- a/src/js/me-plugindetector.js
+++ b/src/js/me-plugindetector.js
@@ -36,7 +36,7 @@ mejs.PluginDetector = {
 			if (description && !(typeof this.nav.mimeTypes != 'undefined' && this.nav.mimeTypes[mimeType] && !this.nav.mimeTypes[mimeType].enabledPlugin)) {
 				version = description.replace(pluginName, '').replace(/^\s+/,'').replace(/\sr/gi,'.').split('.');
 				for (i=0; i<version.length; i++) {
-					version[i] = parseInt(version[i].match(/\d/), 10);
+					version[i] = parseInt(version[i].match(/\d+/), 10);
 				}
 			}
 		// Internet Explorer / ActiveX


### PR DESCRIPTION
detectPlugin was returning [1,1,1] for Flash when parsing version 10's description: 'Shockwave Flash 10.1 r102'. Just modifying the regexp to extract more than one digit from the string components.
