### PR TITLE
IE7 Fix

### DIFF
--- a/src/css/mediaelementplayer.css
+++ b/src/css/mediaelementplayer.css
@@ -1,4 +1,3 @@
-
 .mejs-container {
 	position: relative;
 	background: #000;
@@ -195,6 +194,7 @@
 	width: 30px;
 	display: block;
 	text-align: center;
+	left: 0;
 }
 .mejs-controls .mejs-time-rail .mejs-time-float-corner {
 	position: absolute;


### PR DESCRIPTION
...maybe IE6 too. You can see this bug in the example on your homepage, the time appears too far right.

This is because IE positions the element according to text-align:center. I didn't spot any other issues, but I recommend adding left:0;top:0; to absolutely positioned items that don't already have left/top set, fixes a lot of IE issues.
