### PR TITLE
fix for ie7 failures in last release

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -273,7 +273,7 @@
 						});
 						
 					// check for autoplay
-					if (t.media.getAttribute('autoplay') !== null) {
+					if (t.domNode.getAttribute('autoplay') !== null) {
 						t.controls.css('visibility','hidden');
 					}
 
@@ -282,7 +282,7 @@
 						t.media.addEventListener('loadedmetadata', function(e) {
 							// if the <video height> was not set and the options.videoHeight was not set
 							// then resize to the real dimensions
-							if (t.options.videoHeight <= 0 && t.media.getAttribute('height') === null && !isNaN(e.target.videoHeight)) {
+							if (t.options.videoHeight <= 0 && t.domNode.getAttribute('height') === null && !isNaN(e.target.videoHeight)) {
 								t.setPlayerSize(e.target.videoWidth, e.target.videoHeight);
 								t.setControlsSize();
 								t.media.setVideoSize(e.target.videoWidth, e.target.videoHeight);


### PR DESCRIPTION
t.media is the mediaelement here, and if it's the Flash polyfill, then it doesn't support getAttribute(). Oddly, it was just silently failing for me in IE7, no errors. Not sure of the iOS ramifications of this section?
