### PR TITLE
Quick AS fix for doubled play events in Flash shim mode

### DIFF
--- a/src/flash/htmlelements/VideoElement.as
+++ b/src/flash/htmlelements/VideoElement.as
@@ -269,9 +269,11 @@
 				}
 				_timer.start();
 				_isPaused = false;
-				sendEvent(HtmlMediaEvent.PLAY);
-				sendEvent(HtmlMediaEvent.PLAYING);
 				_hasStartedPlaying = true;
+				
+				// don't toss play/playing events here, because we haven't sent a 
+				// canplay / loadeddata event yet. that'll be handled in the net
+				// event listener
 			}
 
 		}


### PR DESCRIPTION
The SWF was firing play+playing twice on the first start of a movie, and then just once subsequently. Probably doesn't affect many people, but I've added event listeners for analytics.
