### PR TITLE
Make flash audio element fire canplay event after loading, just like html5 element

### DIFF
--- a/src/flash/htmlelements/AudioElement.as
+++ b/src/flash/htmlelements/AudioElement.as
@@ -155,7 +155,12 @@ package htmlelements
 			sendEvent(HtmlMediaEvent.LOADSTART);
 
 			_isLoaded = true;
-
+                        
+                        if (!_firedCanPlay) {
+				sendEvent(HtmlMediaEvent.LOADEDDATA);
+				sendEvent(HtmlMediaEvent.CANPLAY);				
+				_firedCanPlay = true;
+			}
 			if (_playAfterLoading) {
 				_playAfterLoading = false;
 				play();


### PR DESCRIPTION
Flash audio element now fires canplay event after loading, just like html5 element.

**Important:**
This probably has to be fixed for video element as well and for both elements for Silverlight.
