### PR TITLE
added canplay event emit to flash video element and silverlight elements

### DIFF
--- a/src/flash/htmlelements/AudioElement.as
+++ b/src/flash/htmlelements/AudioElement.as
@@ -151,16 +151,14 @@ package htmlelements
 			_sound.load(new URLRequest(_currentUrl));
 			_currentTime = 0;
 			
-			_firedCanPlay = false;
 			sendEvent(HtmlMediaEvent.LOADSTART);
 
 			_isLoaded = true;
-                        
-                        if (!_firedCanPlay) {
-				sendEvent(HtmlMediaEvent.LOADEDDATA);
-				sendEvent(HtmlMediaEvent.CANPLAY);				
-				_firedCanPlay = true;
-			}
+                      
+			sendEvent(HtmlMediaEvent.LOADEDDATA);
+			sendEvent(HtmlMediaEvent.CANPLAY);				
+			_firedCanPlay = true;
+
 			if (_playAfterLoading) {
 				_playAfterLoading = false;
 				play();

--- a/src/flash/htmlelements/VideoElement.as
+++ b/src/flash/htmlelements/VideoElement.as
@@ -245,10 +245,8 @@
 			sendEvent(HtmlMediaEvent.LOADSTART);
 
                         //since flash can always play, while other runtimes require it to first be loaded, fire a canplay event here as well for consistency
-			if (!_firedCanPlay) {
-				sendEvent(HtmlMediaEvent.CANPLAY);
-				_firedCanPlay = true;
-			}
+			sendEvent(HtmlMediaEvent.CANPLAY);
+			_firedCanPlay = true;
 		}
 
 		public function play():void {

--- a/src/silverlight/MainPage.xaml.cs
+++ b/src/silverlight/MainPage.xaml.cs
@@ -330,10 +330,8 @@ namespace SilverlightMediaElement
 			media.AutoPlay = true;
 			media.Source = new Uri(_mediaUrl, UriKind.Absolute);
 			
-			if (!_firedCanPlay) {
-				SendEvent("canplay");
-				_firedCanPlay = true;
-			}
+			SendEvent("canplay");
+			_firedCanPlay = true;
 		}
 
 		[ScriptableMember]


### PR DESCRIPTION
Please look at my code and check if there is no flaw in logic here.

As far as I know, both flash and silverlight can play whenever the load method is called, while html5 has a slight delay after the load method has called.

To be able to play after the load method has been called, the dev should be able to listen to this canplay event; which was not fired by flash/silverlight when changing source and calling mediaElement.load();

Anyway, there could be some flaws here, maybe the event has to be fired elsewhere too - and I'm not sure about the bytesloaded event that seems to be related.
