### PR TITLE
CSS railWidth

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -29,6 +29,9 @@
 		showTimecodeFrameCount: false,
 		// used when showTimecodeFrameCount is set to true
 		framesPerSecond: 25,
+		
+		// override auto rail width calculation
+		useCssRailWidth : true,
 
 		// Hide controls when playing and mouse is not over the video
 		alwaysShowControls: false,
@@ -570,15 +573,30 @@
 				current = t.controls.find('.mejs-time-current'),
 				loaded = t.controls.find('.mejs-time-loaded');
 				others = rail.siblings();
+			
 
-			// find the size of all the other controls besides the rail
-			others.each(function() {
-				if ($(this).css('position') != 'absolute') {
-					usedWidth += $(this).outerWidth(true);
-				}
-			});
-			// fit the rail into the remaining space
-			railWidth = t.controls.width() - usedWidth - (rail.outerWidth(true) - rail.outerWidth(false));
+			// Absolute positions can break the layout.
+			// In depth: the rail extends from the outer 
+			// container, this might be ugly.
+			if (t.options && t.options.useCssRailWidth) {
+				// Also, frontends devs can be more flexible 
+				// due the opportunity of absolute positioning.
+				railWidth = parseInt(rail.css('width'));
+			}
+			
+			
+			if (railWidth === 0 || !railWidth) {
+				
+				// find the size of all the other controls besides the rail
+				others.each(function() {
+					if ($(this).css('position') != 'absolute') {
+						usedWidth += $(this).outerWidth(true);
+					}
+				});
+				
+				// fit the rail into the remaining space
+				railWidth = t.controls.width() - usedWidth - (rail.outerWidth(true) - rail.outerWidth(false));
+			}
 
 			// outer area
 			rail.width(railWidth);


### PR DESCRIPTION
Absolute positions breaks rail width calculation in custom themes .
In depth: the timerail extends from the outer container, this might be ugly.

Also, frontends devs can be more flexible due the opportunity of absolute positioning :)
- added option to use the css width
- invalid css values cause fallback to auto width calculation
- "width: auto" also, because parseInt stop at the first non-numeric char and return 0
