### PR TITLE
Additional check for setVideoSize

### DIFF
--- a/src/js/me-mediaelements.js
+++ b/src/js/me-mediaelements.js
@@ -188,7 +188,7 @@ mejs.PluginMediaElement.prototype = {
 			this.pluginElement.style.width = width + 'px';
 			this.pluginElement.style.height = height + 'px';
 		}
-		if (this.pluginApi != null) {
+		if (this.pluginApi != null && this.pluginApi.setVideoSize) {
 			this.pluginApi.setVideoSize(width, height);
 		}
 	},


### PR DESCRIPTION
When dynamically creating players on a page using 100% w/h, I've found that setVideoSize can be incorrectly called on Flash elements from previous embeds. This check ensures that the method -- and thus the DOM object/embed element -- still exists before attempting a call.
