### PR TITLE
Fade in animation is being cancelled by jQuery .stop

### DIFF
--- a/build/mediaelementplayer.js
+++ b/build/mediaelementplayer.js
@@ -266,12 +266,12 @@ if (typeof jQuery != 'undefined') {
 			if (doAnimation) {
 				t.controls
 					.css('visibility','visible')
-					.stop(true, true).fadeIn(200, function() {t.controlsAreVisible = true;});	
+					.fadeIn(200, function() {t.controlsAreVisible = true;});	
 	
 				// any additional controls people might add and want to hide
 				t.container.find('.mejs-control')
 					.css('visibility','visible')
-					.stop(true, true).fadeIn(200, function() {t.controlsAreVisible = true;});	
+					.fadeIn(200, function() {t.controlsAreVisible = true;});	
 					
 			} else {
 				t.controls


### PR DESCRIPTION
It shouldn't skip the rest of the plugin chain, but for some reason it is. Removed the stop and the transition works beautifully.

The timer that's attached to the control bar should prevent any issues with incomplete transitions, so loosing the stop should be alright.
