### PR TITLE
Add fake DOM attribute methods to mejs.PluginMediaElement

### DIFF
--- a/src/js/me-mediaelements.js
+++ b/src/js/me-mediaelements.js
@@ -300,6 +300,24 @@ mejs.PluginMediaElement.prototype = {
 	},
 	// end: fake events
 	
+	// fake DOM attribute methods
+	attributes: {},
+	hasAttribute: function(name){
+		return (name in this.attributes);  
+	},
+	removeAttribute: function(name){
+		delete this.attributes[name];
+	},
+	getAttribute: function(name){
+		if (this.hasAttribute(name)) {
+			return this.attributes[name];
+		}
+		return '';
+	},
+	setAttribute: function(name, value){
+		this.attributes[name] = value;
+	},
+
 	remove: function() {
 		mejs.Utility.removeSwf(this.pluginElement.id);
 	}

--- a/src/js/me-shim.js
+++ b/src/js/me-shim.js
@@ -385,6 +385,14 @@ mejs.HtmlMediaElementShim = {
 			node,
 			initVars;
 
+		// copy attributes from html media element to plugin media element
+		for (var i = 0; i < htmlMediaElement.attributes.length; i++) {
+			var attribute = htmlMediaElement.attributes[i];
+			if (attribute.specified == true) {
+				pluginMediaElement.setAttribute(attribute.name, attribute.value);
+			}
+		}
+
 		// check for placement inside a <p> tag (sometimes WYSIWYG editors do this)
 		node = htmlMediaElement.parentNode;
 		while (node !== null && node.tagName.toLowerCase() != 'body') {


### PR DESCRIPTION
This pull request adds fake hasAttribute(), removeAttribute(), getAttribute() and setAttribute() methods to the plugin media element. Initial values are set from attributes in the HTML media element.

This functionality is helpful to take advantage of global HTML5 attributes such as title (http://www.w3.org/TR/html5/elements.html#the-title-attribute) and custom data attributes (http://www.w3.org/TR/html5/elements.html#embedding-custom-non-visible-data-with-the-data-attributes). 
