### PR TITLE
Add tagName attribute to mejs.PluginMediaElement

### DIFF
--- a/src/js/me-mediaelements.js
+++ b/src/js/me-mediaelements.js
@@ -86,6 +86,7 @@ mejs.PluginMediaElement.prototype = {
 	seeking: false,
 	duration: 0,
 	error: null,
+	tagName: '',
 
 	// HTML5 get/set properties, but only set (updated by event handlers)
 	muted: false,

--- a/src/js/me-shim.js
+++ b/src/js/me-shim.js
@@ -385,6 +385,9 @@ mejs.HtmlMediaElementShim = {
 			node,
 			initVars;
 
+		// copy tagName from html media element
+		pluginMediaElement.tagName = htmlMediaElement.tagName
+
 		// check for placement inside a <p> tag (sometimes WYSIWYG editors do this)
 		node = htmlMediaElement.parentNode;
 		while (node !== null && node.tagName.toLowerCase() != 'body') {


### PR DESCRIPTION
Add tagName property to mejs.PluginMediaElement (value copied from HTML5 media element). This is useful for determining if the media element is <video> or <audio> using same conventions as HTML5 media elements.
