### PR TITLE
YT iFrame patch

### DIFF
--- a/src/js/me-shim.js
+++ b/src/js/me-shim.js
@@ -704,6 +704,7 @@ mejs.YouTubeApi = {
 	
 	iFrameReady: function() {
 		
+		this.isLoaded = true;
 		this.isIframeLoaded = true;
 		
 		while (this.iframeQueue.length > 0) {


### PR DESCRIPTION
Patch isLoaded variable when iFrame is loaded. We can't load a new YT video without and fail test on line #623.
