### PR TITLE
Make setPlayerSize actually honour the supplied width and height. Fixes #369.

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -693,8 +693,13 @@
 
 		setPlayerSize: function(width,height) {
 			var t = this;
-			
-			// testing for 100% code
+
+			t.width = width;
+			t.height = height;
+
+			// XXX: Dirty hack:
+			// If there is a % char in the supplied height value, set size to
+			// 100% of parent container.
 			if (t.height.toString().indexOf('%') > 0) {
 			
 				// do we have the native dimensions yet?
@@ -970,7 +975,7 @@
 		},
 		changeSkin: function(className) {
 			this.container[0].className = 'mejs-container ' + className;
-			this.setPlayerSize();
+			this.setPlayerSize(this.width, this.height);
 			this.setControlsSize();
 		},
 		play: function() {


### PR DESCRIPTION
This has been broken since 99c372549aa3b314ab312927a4f9db2485494b04 .

I assume this has been left broken just because the common use case for embedding a video doesn't involve resizing. Google reveals that at least two people have been trying to resize the player, based on the github issue #369 and this blog post http://webtonio.com/40/ , but neither bothered to actually fix the code. I ran into the problem when integrating MediaElement into my own video publishing framework.

It's worth noting that setPlayerSize doesn't resize the controls, nor the actual media element; it just resizes the poster, and some other container divs. Perhaps John can elaborate on whether and why it should not also do those things (I'm sure there's a reason, but I'm not 100% familiar with the MediaElement source code yet).

Thanks!
