### PR TITLE
Vertical volume position fix

### DIFF
--- a/src/js/mep-feature-volume.js
+++ b/src/js/mep-feature-volume.js
@@ -46,13 +46,12 @@
 			volumeCurrent = t.container.find('.mejs-volume-current, .mejs-horizontal-volume-current'),
 			volumeHandle = t.container.find('.mejs-volume-handle, .mejs-horizontal-volume-handle'),
 
-			positionVolumeHandle = function(volume, secondTry) {
+			positionVolumeHandle = function(volume) {
 
-				if (!volumeSlider.is(':visible') && typeof secondTry != 'undefined') {
+				var volumeSliderIsVisible = volumeSlider.is(':visible');
+
+				if (!volumeSliderIsVisible) {
 					volumeSlider.show();
-					positionVolumeHandle(volume, true);
-					volumeSlider.hide()
-					return;
 				}
 			
 				// correct to 0-1
@@ -103,6 +102,10 @@
 	
 					// rezize the current part of the volume bar
 					volumeCurrent.width( newLeft );
+				}
+				
+				if (!volumeSliderIsVisible) {
+					volumeSlider.hide();
 				}
 			},
 			handleVolumeMove = function(e) {


### PR DESCRIPTION
.... This is required so the actual top positions can be found (if the volumeSlider is not visible, volumeTotal.position().top is always 0).

This fixes cases where the volumeTotal and volumeCurrent have their top position set to anything other than 0.

I have only changed src/js/mep-feature-volume.js as I wasn't sure how to run the build so the media element js files will need to be built after this commit.
