### PR TITLE
Better file MIME type detection when the "type" attribute is not specified

### DIFF
--- a/src/js/me-shim.js
+++ b/src/js/me-shim.js
@@ -348,7 +348,23 @@ mejs.HtmlMediaElementShim = {
 	
 	getTypeFromFile: function(url) {
 		var ext = url.substring(url.lastIndexOf('.') + 1);
-		return (/(mp4|m4v|ogg|ogv|webm|flv|wmv|mpeg|mov)/gi.test(ext) ? 'video' : 'audio') + '/' + ext;
+		return (/(mp4|m4v|ogg|ogv|webm|webmv|flv|wmv|mpeg|mov)/gi.test(ext) ? 'video' : 'audio') + '/' + this.getTypeFromExtension(ext);
+	},
+	
+	getTypeFromExtension: function(ext) {
+		var ext_types = {
+			'mp4': ['mp4','m4v'],
+			'ogg': ['ogg','ogv','oga'],
+			'webm': ['webm','webmv','webma']
+		};
+		var r = ext;
+		$.each(ext_types, function(key, value) {
+			if (value.indexOf(ext) > -1) {
+				r = key;
+				return;
+			}
+		});
+		return r;
 	},
 
 	createErrorMessage: function(playback, options, poster) {


### PR DESCRIPTION
Better file MIME type detection when the "type" attribute is not specified on the video or audio tag.

Before this patch, MIME type retrieved for files with .ogv extension was "video/ogv". => canPlayType() fails and mediaelement was not able to display the video while it should.

Now, MIME type retrieved for files with .ogv extension is correct : "video/ogg".

Same for .oga, .webmv, .webma, .m4v.
