### PR TITLE
Use inArray rather than indexOf in getTypeFromExtension to support IE < 9

### DIFF
--- a/src/js/me-shim.js
+++ b/src/js/me-shim.js
@@ -369,7 +369,7 @@ mejs.HtmlMediaElementShim = {
 		};
 		var r = ext;
 		$.each(ext_types, function(key, value) {
-			if (value.indexOf(ext) > -1) {
+			if ($.inArray(ext, value) > -1) {
 				r = key;
 				return;
 			}


### PR DESCRIPTION
IE < 9 doesn't support indexOf for arrays, so it will throw a method not supported error when searching for the extension in the type array. Switching to jQuery's inArray should fix this.
