### PR TITLE
attempted fix for Issue #548

### DIFF
--- a/build/mediaelement-and-player.js
+++ b/build/mediaelement-and-player.js
@@ -1286,7 +1286,7 @@ if (typeof jQuery != 'undefined') {
 			var t = this,
 				doAnimation = typeof doAnimation == 'undefined' || doAnimation;
 			
-			if (!t.controlsAreVisible)
+			if (!t.controlsAreVisible || t.options.alwaysShowControls) // attempted fix for Issue #548
 				return;
 			
 			if (doAnimation) {


### PR DESCRIPTION
As detailed in Issue #548, if alwaysShowControls is set to true, the
player will still hide the controls if the keyboard is used to
manipulate the player. By adding to this if statement, I prevent the
controls from hiding in that case.
