### PR TITLE
Fixing syntax error in events demo

### DIFF
--- a/demo/mediaelementplayer-events.html
+++ b/demo/mediaelementplayer-events.html
@@ -39,7 +39,7 @@ $('video').mediaelementplayer({
 			var eventName = events[i];
 			
 			media.addEventListener(events[i], function(e) {
-				$('#output').append( $('<div>' + e.type + '</div>');
+				$('#output').append( $('<div>' + e.type + '</div>') );
 			});
 			
 		}


### PR DESCRIPTION
There is a missing parenthesis in the events demo which renders it useless. Here's a fix!
