### PR TITLE
Fixed bug in mep-feature-sourcechooser.js:48, added type to source buttons

### DIFF
--- a/src/js/mep-feature-sourcechooser.js
+++ b/src/js/mep-feature-sourcechooser.js
@@ -45,22 +45,23 @@
 			for (i in media.children) {
 				src = media.children[i];
 				if (src.nodeName === 'SOURCE' && (media.canPlayType(src.type) == 'probably' || media.canPlayType(src.type) == 'maybe')) {
-					player.addSourceButton(src.src, src.title, media.currentSrc == src.src);
+					player.addSourceButton(src.src, src.title, src.type, media.src == src.src);
 				}
 			}
 
 		},
 
-		addSourceButton: function(src, label, isCurrent) {
+		addSourceButton: function(src, label, type, isCurrent) {
 			var t = this;
 			if (label === '' || label == undefined) {
 				label = src;
 			}
+			type = type.split('/')[1];
 
 			t.sourcechooserButton.find('ul').append(
 				$('<li>'+
-					'<input type="radio" name="' + t.id + '_sourcechooser" id="' + t.id + '_sourcechooser_' + label + '" value="' + src + '" ' + (isCurrent ? 'checked="checked"' : '') + ' />'+
-					'<label for="' + t.id + '_sourcechooser_' + label + '">' + label + '</label>'+
+					'<input type="radio" name="' + t.id + '_sourcechooser" id="' + t.id + '_sourcechooser_' + label + type + '" value="' + src + '" ' + (isCurrent ? 'checked="checked"' : '') + ' />'+
+					'<label for="' + t.id + '_sourcechooser_' + label + type + '">' + label + ' (' + type + ')</label>'+
 				'</li>')
 			);
 


### PR DESCRIPTION
Fixed bug on line 48: Replaced invalid media.currentSrc property with media.src property.

Added src.type to addSourceButton() call and definition. Using content after the '/' to display (and differentiate between in ids) the types of the videos.
