### PR TITLE
Volume handle doesn't set initial position properly

### DIFF
--- a/src/js/mep-feature-volume.js
+++ b/src/js/mep-feature-volume.js
@@ -81,11 +81,11 @@
 						newTop = totalHeight - (totalHeight * volume);
 	
 					// handle
-					volumeHandle.css('top', totalPosition.top + newTop - (volumeHandle.height() / 2));
+					volumeHandle.css(Math.round('top', totalPosition.top + newTop - (volumeHandle.height() / 2)));
 	
 					// show the current visibility
-					volumeCurrent.height(totalHeight - newTop );
-					volumeCurrent.css('top', totalPosition.top + newTop);
+					volumeCurrent.height(Math.round(totalHeight - newTop));
+					volumeCurrent.css('top', Math.round(totalPosition.top + newTop));
 				} else {
 					var 
 					
@@ -99,10 +99,10 @@
 						newLeft = totalWidth * volume;
 	
 					// handle
-					volumeHandle.css('left', totalPosition.left + newLeft - (volumeHandle.width() / 2));
+					volumeHandle.css('left', Math.round(totalPosition.left + newLeft - (volumeHandle.width() / 2));
 	
 					// rezize the current part of the volume bar
-					volumeCurrent.width( newLeft );
+					volumeCurrent.width(Math.round(newLeft));
 				}
 			},
 			handleVolumeMove = function(e) {


### PR DESCRIPTION
The volume handle must be visible when its position is set, but `secondTry` isn't detected due to the wrong operator being used in a boolean statement:

``` javascript
if (!volumeSlider.is(':visible') && typeof secondTry != 'undefined') {
    volumeSlider.show();
    positionVolumeHandle(volume, true);
    volumeSlider.hide()
    return;
}
```

In the above code, it should check to see if `typeof secondTry === 'undefined'`.

I have also rounded height/width/position of the volume handle and currents - if they're not rounded, they can be seen off by a pixel at times. Also, jQuery rounds improperly upon calling `.top`, `.width` or `.height` inside `handleVolumeMove`.
