### PR TITLE
Display chapter tracks for late-loading video sources, including YouTube

### DIFF
--- a/src/js/mep-feature-tracks.js
+++ b/src/js/mep-feature-tracks.js
@@ -179,8 +179,12 @@
 					
 					after();
 
-					if (track.kind == 'chapters' && t.media.duration > 0) {
-						t.drawChapters(track);
+					if (track.kind == 'chapters') {
+						t.media.addEventListener('play', function(e) {
+							if (t.media.duration > 0) {
+								t.displayChapters(track);
+							}
+						}, false);
 					}
 				},
 				error: function() {


### PR DESCRIPTION
Hi, I find that a video’s chapter track fails to be used if the source loads late, such as if it comes from YouTube or is impacted by a plugin blocker. This is because the chapter track loads before the media duration is known, and later for YouTube sources the loadedmetadata event is not triggered. One workaround is for the chapter track to be displayed by some other event, like play.
