### PR TITLE
Fix audio height in 100% mode

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -717,14 +717,14 @@
 					nativeWidth = t.isVideo ? ((t.media.videoWidth && t.media.videoWidth > 0) ? t.media.videoWidth : t.options.defaultVideoWidth) : t.options.defaultAudioWidth,
 					nativeHeight = t.isVideo ? ((t.media.videoHeight && t.media.videoHeight > 0) ? t.media.videoHeight : t.options.defaultVideoHeight) : t.options.defaultAudioHeight,
 					parentWidth = t.container.parent().closest(':visible').width(),
-					newHeight = parseInt(parentWidth * nativeHeight/nativeWidth, 10);
+					newHeight = t.isVideo || !t.options.autosizeProgress ? parseInt(parentWidth * nativeHeight/nativeWidth, 10) : nativeHeight;
 					
 				if (t.container.parent()[0].tagName.toLowerCase() === 'body') { // && t.container.siblings().count == 0) {
 					parentWidth = $(window).width();
 					newHeight = $(window).height();
 				}
 				
-				if ( newHeight != 0 ) {
+				if ( newHeight != 0 && parentWidth != 0 ) {
 					// set outer container size
 					t.container
 						.width(parentWidth)


### PR DESCRIPTION
This changes the way the audio player works in the 100% width mode. Since audio elements don't actually have a height, the controls are the only height to the audio element. This makes it so the audio player will still be the height of the controls if the progress is set to autosize.
