### PR TITLE
Select first source that is supported by the browser

### DIFF
--- a/src/js/me-mediaelements.js
+++ b/src/js/me-mediaelements.js
@@ -43,6 +43,7 @@ mejs.HtmlMediaElement = {
 				media = url[i];
 				if (this.canPlayType(media.type)) {
 					this.src = media.src;
+					break;
 				}
 			}
 		}
@@ -190,6 +191,7 @@ mejs.PluginMediaElement.prototype = {
 				if (this.canPlayType(media.type)) {
 					this.pluginApi.setSrc(mejs.Utility.absolutizeUrl(media.src));
 					this.src = mejs.Utility.absolutizeUrl(url);
+					break;
 				}
 			}
 		}


### PR DESCRIPTION
From my point of view it makes sense to use the first compatible media file instead of the last one if provided via setSrc().

Example:
element.setSrc([
    {type: 'video/mp4', src: 'video.mp4'},
    {type: 'video/webm', src: 'video.webm'}])
]);

In this case Google Chrome would select the webm file although it supports mp4 files as well. This is inconsistent with the HTML5 syntax where the first supported source will be used.
