### PR TITLE
fixed outerWidth for jQuery 1.8 compatiability

### DIFF
--- a/src/js/mep-feature-progress.js
+++ b/src/js/mep-feature-progress.js
@@ -30,7 +30,7 @@
 					// mouse position relative to the object
 					var x = e.pageX,
 						offset = total.offset(),
-						width = total.outerWidth(),
+						width = total.outerWidth(true),
 						percentage = 0,
 						newTime = 0,
 						pos = x - offset.left;


### PR DESCRIPTION
jQuery 1.8 requires outerWidth to specify boolean, "total.outerWidth" was missing (true)
