### PR TITLE
Use the normal CSS property name after the vendor prefix

### DIFF
--- a/src/css/mediaelementplayer.css
+++ b/src/css/mediaelementplayer.css
@@ -180,9 +180,9 @@
 	overflow: hidden;
 	text-align: center;
 	padding: auto 4px;
-	box-sizing: content-box;
 	-moz-box-sizing: content-box;
 	-webkit-box-sizing: content-box;
+	box-sizing: content-box;
 }
 .mejs-container .mejs-controls .mejs-time span {
 	font-size: 11px;


### PR DESCRIPTION
There is an article in [CSS-Tricks](http://css-tricks.com/ordering-css3-properties/) with an explanation why this is a good idea and also Chrome audit complains about it if the vendor prefixed one is last.
