### PR TITLE
max-width check doesn't work in IE

### DIFF
--- a/src/js/me-shim.js
+++ b/src/js/me-shim.js
@@ -43,6 +43,9 @@ mejs.MediaPluginBridge = {
 			bufferedTime,
 			pluginMediaElement = this.pluginMediaElements[id];
 
+		pluginMediaElement.ended = false;
+		pluginMediaElement.paused = true;
+
 		// fake event object to mimic real HTML media event.
 		e = {
 			type: eventName,

--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -534,14 +534,18 @@
 						});					
 					
 					} else {
-            // click to play/pause
-            t.media.addEventListener('click', function() {
-              if (t.media.paused) {
-                t.media.play();
-              } else {
-                t.media.pause();
-              }
-            });
+						// click controls
+						var clickElement = (t.media.pluginType == 'native') ? t.$media : $(t.media.pluginElement);
+						
+						// click to play/pause
+						clickElement.click(function() {
+							if (media.paused) {
+								media.play();
+							} else {
+								media.pause();
+							}
+						});
+						
 					
 						// show/hide controls
 						t.container


### PR DESCRIPTION
The video player resizing functionality doesn't work in IE because its implementation of getComputedStyle (correctly) returns a pixel measurement instead of a percentage, hence the check for "%" returns false.

This fix will check to see if currentStyle exists on DOM elements, and queries them to find possible percentages.
