### PR TITLE
PluginMediaElement click-to-pause behavior doesn't work

### DIFF
--- a/src/js/me-shim.js
+++ b/src/js/me-shim.js
@@ -43,9 +43,6 @@ mejs.MediaPluginBridge = {
 			bufferedTime,
 			pluginMediaElement = this.pluginMediaElements[id];
 
-		pluginMediaElement.ended = false;
-		pluginMediaElement.paused = true;
-
 		// fake event object to mimic real HTML media event.
 		e = {
 			type: eventName,

--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -534,18 +534,14 @@
 						});					
 					
 					} else {
-						// click controls
-						var clickElement = (t.media.pluginType == 'native') ? t.$media : $(t.media.pluginElement);
-						
-						// click to play/pause
-						clickElement.click(function() {
-							if (media.paused) {
-								media.play();
-							} else {
-								media.pause();
-							}
-						});
-						
+            // click to play/pause
+            t.media.addEventListener('click', function() {
+              if (t.media.paused) {
+                t.media.play();
+              } else {
+                t.media.pause();
+              }
+            });
 					
 						// show/hide controls
 						t.container


### PR DESCRIPTION
The original code tried to attach a click listener to the <embed> object. That doesn't work. The code now listens for a click event via the internal addEventListener function.

Also removed some nonsensical state changes in fireEvent that were causing the player to believe it was paused.
