### PR TITLE
Bugfix: Time float overflow

### DIFF
--- a/src/css/mediaelementplayer.css
+++ b/src/css/mediaelementplayer.css
@@ -321,6 +321,7 @@
 	text-align: center;
 	left: 0;
 }
+
 .mejs-controls .mejs-time-rail .mejs-time-float-corner {
 	position: absolute;
 	display: block;
@@ -334,9 +335,19 @@
 	border-radius: 0;
 	top: 15px;
 	left: 13px;
-
 }
 
+.mejs-long-video .mejs-controls .mejs-time-rail .mejs-time-float {
+	width: 48px;
+}
+
+.mejs-long-video .mejs-controls .mejs-time-rail .mejs-time-float-current {
+	width: 44px;
+}
+
+.mejs-long-video .mejs-controls .mejs-time-rail .mejs-time-float-corner {
+	left: 18px;
+}
 
 
 

--- a/src/js/mep-feature-time.js
+++ b/src/js/mep-feature-time.js
@@ -71,6 +71,9 @@
 		
 		updateDuration: function() {	
 			var t = this;
+
+			//Toggle the long video class if the video is longer than an hour.
+			t.container.toggleClass("mejs-long-video", t.media.duration > 3600);
 			
 			if (t.media.duration && t.durationD) {
 				t.durationD.html(mejs.Utility.secondsToTimeCode(t.media.duration, t.options.alwaysShowHours, t.options.showTimecodeFrameCount, t.options.framesPerSecond || 25));


### PR DESCRIPTION
When the video being played is over an hour long, the timefloat text overflows. The pull request fixes this issue by widening the float to support the overflow.

![timefloat](https://f.cloud.github.com/assets/1066579/65537/23f0ed9e-5e81-11e2-8b22-598cc52cf31a.png)
