### PR TITLE
Added option to disable pause/play on main div click

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -50,6 +50,8 @@
 		autosizeProgress : true,
 		// Hide controls when playing and mouse is not over the video
 		alwaysShowControls: false,
+        // Enable click video element to toggle play/pause
+        clickToPlayPause: true,
 		// force iPad's native controls
 		iPadUseNativeControls: false,
 		// force iPhone's native controls
@@ -547,10 +549,12 @@
 					} else {
             // click to play/pause
             t.media.addEventListener('click', function() {
-              if (t.media.paused) {
-                t.media.play();
-              } else {
-                t.media.pause();
+              if (t.options.clickToPlayPause) {
+                  if (t.media.paused) {
+                    t.media.play();
+                  } else {
+                    t.media.pause();
+                  }
               }
             });
 					
@@ -862,6 +866,7 @@
 		},
 
 		buildoverlays: function(player, controls, layers, media) {
+            var t = this;
 			if (!player.isVideo)
 				return;
 
@@ -885,11 +890,13 @@
 				'</div>')
 				.appendTo(layers)
 				.click(function() {
-					if (media.paused) {
-						media.play();
-					} else {
-						media.pause();
-					}
+                    if (t.options.clickToPlayPause) {
+                        if (media.paused) {
+                            media.play();
+                        } else {
+                            media.pause();
+                        }
+                    }
 				});
 			
 			/*


### PR DESCRIPTION
The main idea here is, in certain situations, you may not want the user to control the player by clicking on the main player div.  You would like to limit it to either the built-in controls, or an external control.  This change allows that control.
