### PR TITLE
Fix broken scrollbar

### DIFF
--- a/src/js/mep-feature-progress.js
+++ b/src/js/mep-feature-progress.js
@@ -48,7 +48,7 @@
 						newTime = (percentage <= 0.02) ? 0 : percentage * media.duration;
 
 						// seek to where the mouse is
-						if (mouseIsDown && newTime !== media.getCurrentTime()) {
+						if (mouseIsDown && newTime !== player.getCurrentTime()) {
 							media.setCurrentTime(newTime);
 						}
 


### PR DESCRIPTION
The media variable refers to the html5 video, the player variable refers to the
mediaelement.js player. This change fixes the broken seek bar due to no getCurrentTime
method on the media variable. This was broken in (at least) Chrome and Firefox on the
sample video on mediaelementjs.com.
