### PR TITLE
Fixed recent changelog dates (should be 2013)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ You can use this as a standalone library if you wish, or just stick with the ful
 * Ogg/Theora playback
 * Better alignment with native MediaElement (using shimichanga.com techniques)	
 
-*2.10.3 (2012/01/27)*
+*2.10.3 (2013/01/27)*
 
 * Fix broken scrollbar from API reference error (peterbrook) (https://github.com/johndyer/mediaelement/pull/739)
 
-*2.10.2 (2012/01/26)*
+*2.10.2 (2013/01/26)*
 
 * The project is now MIT-only, instead of dual licensed MIT and GPL (just as jQuery has done: http://jquery.org/license/)
 * Fix audio height in 100% mode (https://github.com/johndyer/mediaelement/pull/667)


### PR DESCRIPTION
The most recent changes were made in 2013, not 2012. I updated the readme to reflect this.
