### PR TITLE
Muting the volume icon if startVolume is set to 0

### DIFF
--- a/src/js/mep-feature-volume.js
+++ b/src/js/mep-feature-volume.js
@@ -209,7 +209,12 @@
 			if (t.container.is(':visible')) {
 				// set initial volume
 				positionVolumeHandle(player.options.startVolume);
-				
+
+				// mutes the media and sets the volume icon muted if the initial volume is set to 0
+        if (player.options.startVolume === 0) {
+          media.setMuted(true);
+        }
+
 				// shim gets the startvolume as a parameter, but we have to set it on the native <video> and <audio> elements
 				if (media.pluginType === 'native') {
 					media.setVolume(player.options.startVolume);


### PR DESCRIPTION
...l (to match the dragging functionality of the volume slider)

My previous solution was a bit ugly, because it triggered a button click event;
