### PR TITLE
Fix the "caterpillar"-like behavior on Chrome

### DIFF
--- a/src/js/mep-feature-progress.js
+++ b/src/js/mep-feature-progress.js
@@ -161,8 +161,8 @@
 				// update bar and handle
 				if (t.total && t.handle) {
 					var 
-						newWidth = t.total.width() * t.media.currentTime / t.media.duration,
-						handlePos = newWidth - (t.handle.outerWidth(true) / 2);
+						newWidth = Math.round(t.total.width() * t.media.currentTime / t.media.duration),
+						handlePos = newWidth - Math.round(t.handle.outerWidth(true) / 2);
 
 					t.current.width(newWidth);
 					t.handle.css('left', handlePos);


### PR DESCRIPTION
We have the handle styled differently then the original, and it's always visible.
It exhibits an annoying "caterpillar"-like effect on chrome when it shrinks and expands.
It looks like Chrome is handling fractional pixels differently than FF.
