### PR TITLE
Make possible to open youtube links as audio only

### DIFF
--- a/src/js/me-namespace.js
+++ b/src/js/me-namespace.js
@@ -17,7 +17,7 @@ mejs.plugins = {
 		//,{version: [12,0], types: ['video/webm']} // for future reference (hopefully!)
 	],
 	youtube: [
-		{version: null, types: ['video/youtube', 'video/x-youtube']}
+		{version: null, types: ['video/youtube', 'video/x-youtube', 'audio/youtube', 'audio/x-youtube']}
 	],
 	vimeo: [
 		{version: null, types: ['video/vimeo', 'video/x-vimeo']}


### PR DESCRIPTION
This add to youtube plugin the ability to open youtube links as audio only (without image, only the control panel)
