### PR TITLE
Bug fix for the error "this.pluginApi.pauseMedia is not a function" when using the flash player and removing the dom element.

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -1068,6 +1068,9 @@
 			if (!t.isDynamic) {
 				t.$node.insertBefore(t.container)
 			}
+
+			// Remove the player from the mejs.players array so that pauseOtherPlayers doesn't blow up when trying to pause a non existance flash api.
+			mejs.players.splice( $.inArray( t, mejs.players ), 1);
 			
 			t.container.remove();
 		}


### PR DESCRIPTION
When the player's "remove" function is called it doesn't
remove the internal reference to the removed player. This means that when the below are true an error is thrown when the next video is played.
- pauseOtherPlayers option is true
- the player being used is flash
- the player.remove function is called
- flash dom element has been removed 
