### PR TITLE
Fixes: Warning: $(html) HTML strings must start with '<' character

### DIFF
--- a/src/js/mep-feature-time.js
+++ b/src/js/mep-feature-time.js
@@ -3,7 +3,7 @@
 	// options
 	$.extend(mejs.MepDefaults, {
 		duration: -1,
-		timeAndDurationSeparator: ' <span> | </span> '
+		timeAndDurationSeparator: '<span> | </span>'
 	});
 
 


### PR DESCRIPTION
Removed leading space from timeAndDurationSeparator.
