### PR TITLE
"splice is not a function" fix on MEP.remove() [follow-up from #779 and #788]

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -1087,13 +1087,12 @@
 				/*else*/ t.$node.insertBefore(t.container)
 			}
 
-			// Remove the player from the mejs.players array so that pauseOtherPlayers doesn't blow up when trying to pause a non existance flash api.
-			mejs.players.splice( $.inArray( t, mejs.players ), 1);
+			// Remove the player from the mejs.players object so that pauseOtherPlayers doesn't blow up when trying to pause a non existance flash api.
+			delete mejs.players[t.id];
 			
 			t.container.remove();
 			t.globalUnbind();
 			delete t.node.player;
-			delete mejs.players[t.id];
 		}
 	};
 


### PR DESCRIPTION
#788 tried to fix part of what #779 did, but didn't acknowledge that `mejs.players` is no longer an array, being an object now (a change introduced by #779). As such, remove() now throws a "splice is not a function" error at that point.

This fix replaces the line added by #788 with #779's equivalent, but preserves (and rectifies) the comment above.
