### PR TITLE
Force fullscreen "hover divs" to be hidden on load

### DIFF
--- a/src/js/mep-feature-fullscreen.js
+++ b/src/js/mep-feature-fullscreen.js
@@ -120,9 +120,9 @@
 									fullscreenIsDisabled = false;
 								}
 							},
-							videoHoverDiv = $('<div class="mejs-fullscreen-hover" />').appendTo(t.container).mouseover(restoreControls),
-							controlsLeftHoverDiv = $('<div class="mejs-fullscreen-hover"  />').appendTo(t.container).mouseover(restoreControls),
-							controlsRightHoverDiv = $('<div class="mejs-fullscreen-hover"  />').appendTo(t.container).mouseover(restoreControls),
+							videoHoverDiv = $('<div class="mejs-fullscreen-hover" />').appendTo(t.container).mouseover(restoreControls).hide(),
+							controlsLeftHoverDiv = $('<div class="mejs-fullscreen-hover"  />').appendTo(t.container).mouseover(restoreControls).hide(),
+							controlsRightHoverDiv = $('<div class="mejs-fullscreen-hover"  />').appendTo(t.container).mouseover(restoreControls).hide(),
 							positionHoverDivs = function() {
 								var style = {position: 'absolute', top: 0, left: 0}; //, backgroundColor: '#f00'};
 								videoHoverDiv.css(style);


### PR DESCRIPTION
This PR prevents the "hover divs" added by the fullscreen feature from staying above the player and controls when, after the player is loaded, the browser window is resized _before the user mouses over the fullscreen button for the first time_. (Interestingly, the fullscreen button can still be hovered, bringing things back to normal.)
