### PR TITLE
<audio> tag not in DOM fails in IE8

### DIFF
--- a/src/js/me-shim.js
+++ b/src/js/me-shim.js
@@ -451,7 +451,7 @@ mejs.HtmlMediaElementShim = {
 
 		// check for placement inside a <p> tag (sometimes WYSIWYG editors do this)
 		node = htmlMediaElement.parentNode;
-		while (node !== null && node.tagName.toLowerCase() != 'body') {
+		while (node !== null && node.tagName.toLowerCase() != 'body' && node.parentNode && node.parentNode.parentNode) {
 			if (node.parentNode.tagName.toLowerCase() == 'p') {
 				node.parentNode.parentNode.insertBefore(node, node.parentNode);
 				break;


### PR DESCRIPTION
In IE8 if you create an `<audio>` element outside of the document it will behave different then in modern browsers.
Let's say we create and initialise the element like this:

``` javascript
var element = $('<audio src="jo.mp3" />')[0];
new MediaElement(element);
```

In IE8 the element's `parentNode` will be set to a `HTMLDocument` object, which has no `tagName` property, so the following code will fail:

``` javascript
node = htmlMediaElement.parentNode;
while (node !== null && node.tagName.toLowerCase() != 'body') {
```
