### PR TITLE
Option for custom error message when no plugins are found.

### DIFF
--- a/src/js/me-shim.js
+++ b/src/js/me-shim.js
@@ -406,9 +406,13 @@ mejs.HtmlMediaElementShim = {
 			errorContainer.style.height = htmlMediaElement.height + 'px';
 		} catch (e) {}
 
-		errorContainer.innerHTML = (poster !== '') ?
-			'<a href="' + playback.url + '"><img src="' + poster + '" width="100%" height="100%" /></a>' :
-			'<a href="' + playback.url + '"><span>' + mejs.i18n.t('Download File') + '</span></a>';
+    if (options.customError) {
+      errorContainer.innerHTML = options.customError;
+    } else {
+      errorContainer.innerHTML = (poster !== '') ?
+        '<a href="' + playback.url + '"><img src="' + poster + '" width="100%" height="100%" /></a>' :
+        '<a href="' + playback.url + '"><span>' + mejs.i18n.t('Download File') + '</span></a>';
+    }
 
 		htmlMediaElement.parentNode.insertBefore(errorContainer, htmlMediaElement);
 		htmlMediaElement.style.display = 'none';


### PR DESCRIPTION
We wanted to be able to i.e. prompt the user to install Flash if they were on a platform requiring Flash and it was not yet installed.

This is a very simple implementation, you can just provide an error message in the mejs options. If it is not provided, you get the current message, a download link to the media file.

I need the functionality, but I'm not attached to this implementation. If anybody favors a different approach, please let me know.
