### PR TITLE
i18n fixes for better compatibility with WordPress

### DIFF
--- a/src/js/me-i18n.js
+++ b/src/js/me-i18n.js
@@ -58,7 +58,7 @@
      * @see: i18n.methods.t()
      */
     i18n.locale.getLanguage = function () {
-        return {
+        return mejs.locale || {
             "language" : navigator.language
         };
     };
@@ -192,3 +192,13 @@
 // end i18n
     exports.i18n = i18n;
 }(document, mejs));
+
+;(function(exports, undefined) {
+
+	"use strict";
+
+	if ( mejs.locale.language && mejs.locale.strings ) {
+		exports[mejs.locale.language] = mejs.locale.strings;
+	}
+
+}(mejs.i18n.locale.strings));

--- a/src/js/mep-feature-contextmenu.js
+++ b/src/js/mep-feature-contextmenu.js
@@ -17,9 +17,9 @@ $.extend(mejs.MepDefaults,
 					return null;
 			
 				if (player.isFullScreen) {
-					return "Turn off Fullscreen";
+					return mejs.i18n.t('Turn off Fullscreen');
 				} else {
-					return "Go Fullscreen";
+					return mejs.i18n.t('Go Fullscreen');
 				}
 			},
 			click: function(player) {
@@ -35,9 +35,9 @@ $.extend(mejs.MepDefaults,
 		{ 
 			render: function(player) {
 				if (player.media.muted) {
-					return "Unmute";
+					return mejs.i18n.t('Unmute');
 				} else {
-					return "Mute";
+					return mejs.i18n.t('Mute');
 				}
 			},
 			click: function(player) {
@@ -56,7 +56,7 @@ $.extend(mejs.MepDefaults,
 		// demo of simple download video
 		{ 
 			render: function(player) {
-				return "Download Video";
+				return mejs.i18n.t('Download Video');
 			},
 			click: function(player) {
 				window.location.href = player.media.currentSrc;

--- a/src/js/mep-feature-playpause.js
+++ b/src/js/mep-feature-playpause.js
@@ -1,7 +1,7 @@
 (function($) {
 
 	$.extend(mejs.MepDefaults, {
-		playpauseText: 'Play/Pause'
+		playpauseText: mejs.i18n.t('Play/Pause')
 	});
 
 	// PLAY/pause BUTTON

--- a/src/js/mep-feature-tracks.js
+++ b/src/js/mep-feature-tracks.js
@@ -5,7 +5,7 @@
 		// this will automatically turn on a <track>
 		startLanguage: '',
 
-		tracksText: 'Captions/Subtitles',
+		tracksText: mejs.i18n.t('Captions/Subtitles'),
 		
 		// option to remove the [cc] button when no <track kind="subtitles"> are present
 		hideCaptionsButtonWhenEmpty: true,
@@ -43,7 +43,7 @@
 							'<ul>'+
 								'<li>'+
 									'<input type="radio" name="' + player.id + '_captions" id="' + player.id + '_captions_none" value="none" checked="checked" />' +
-									'<label for="' + player.id + '_captions_none">None</label>'+
+									'<label for="' + player.id + '_captions_none">' + mejs.i18n.t('None') +'</label>'+
 								'</li>'	+
 							'</ul>'+
 						'</div>'+

--- a/src/js/mep-feature-volume.js
+++ b/src/js/mep-feature-volume.js
@@ -1,7 +1,7 @@
 (function($) {
 
 	$.extend(mejs.MepDefaults, {
-		muteText: 'Mute Toggle',
+		muteText: mejs.i18n.t('Mute Toggle'),
 		hideVolumeOnTouchDevices: true,
 		
 		audioVolume: 'horizontal',


### PR DESCRIPTION
- Allow translations to be passed as an array of strings.
- Make some hard-coded strings translatable.

props @dimadin. see #849.
