### PR TITLE
Fullscreen doesn't properly check for plugin type

### DIFF
--- a/src/js/mep-feature-fullscreen.js
+++ b/src/js/mep-feature-fullscreen.js
@@ -374,7 +374,7 @@
 				}, 500);
 			//}
 
-			if (t.pluginType === 'native') {
+			if (t.media.pluginType === 'native') {
 				t.$media
 					.width('100%')
 					.height('100%');
@@ -430,12 +430,12 @@
 				.height(normalHeight);
 				//.css({position: '', left: '', top: '', right: '', bottom: '', overflow: 'inherit', width: normalWidth + 'px', height: normalHeight + 'px', 'z-index': 1});
 
-			if (t.pluginType === 'native') {
+			if (t.media.pluginType === 'native') {
 				t.$media
 					.width(normalWidth)
 					.height(normalHeight);
 			} else {
-				t.container.find('object embed')
+				t.container.find('.mejs-shim')
 					.width(normalWidth)
 					.height(normalHeight);
 


### PR DESCRIPTION
When resizing the media, MEJS tests for mediaelementplayer.pluginType, which is undefined, instead of mediaelementplayer.media.pluginType. Not sure when this broke, but it caused our videos not to stretch to the fullscreen container.

This fix changes that, and also replaces one rogue mention of "object embed" with the proper ".mejs-shim".
