### PR TITLE
Properly treat namespace-only events for `globalUnbind()` as pertaining to both `document` and `window`.

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -1111,7 +1111,14 @@
 			// add player ID as an event namespace so it's easier to unbind them all later
 			var ret = {d: [], w: []};
 			$.each((events || '').split(' '), function(k, v){
-				ret[rwindow.test(v) ? 'w' : 'd'].push(v + '.' + id);
+				var eventname = v + '.' + id;
+				if (eventname.indexOf('.') === 0) {
+					ret.d.push(eventname);
+					ret.w.push(eventname);
+				}
+				else {
+					ret[rwindow.test(v) ? 'w' : 'd'].push(eventname);
+				}
 			});
 			ret.d = ret.d.join(' ');
 			ret.w = ret.w.join(' ');


### PR DESCRIPTION
Events with only namespaces (`.name.space`, and also the empty string) should be treated by `globalUnbind()` as pertaining to both `document` and `window`, so no events will be left behind.

This is a followup from #779, should address the leak pointed out by #874.
