### PR TITLE
change default separate string

### DIFF
--- a/src/js/mep-feature-time.js
+++ b/src/js/mep-feature-time.js
@@ -3,7 +3,7 @@
 	// options
 	$.extend(mejs.MepDefaults, {
 		duration: -1,
-		timeAndDurationSeparator: ' <span> | </span> '
+		timeAndDurationSeparator: ' <span> / </span> '
 	});
 
 


### PR DESCRIPTION
Because jQuery constructer returns "Unrecognized expression" Exception
maybe implements newer jQuery with security reason$
