### PR TITLE
Fix for Issue #852

### DIFF
--- a/src/js/me-shim.js
+++ b/src/js/me-shim.js
@@ -617,6 +617,8 @@ mejs.HtmlMediaElementShim = {
 		}
 		// hide original element
 		htmlMediaElement.style.display = 'none';
+		// prevent browser from autoplaying when using a plugin
+		htmlMediaElement.removeAttribute('autoplay');
 
 		// FYI: options.success will be fired by the MediaPluginBridge
 		


### PR DESCRIPTION
Here is a fix for Issue #852.

Chrome will autoplay the same file twice when using plugins. It seems to happen on longer running scripts or dynamically added audio elements more often.
