### PR TITLE
fix play() on ipad does not start playing and double click issue

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -566,6 +566,7 @@
 							}
 						};
 
+			            // click to play/pause
 			            t.media.addEventListener('click', t.clickToPlayPauseCallback, false);
 
 						// show/hide controls


### PR DESCRIPTION
I have seen some issues with mediaelement and manually starting a video on the ipad. 

I have changed the code that a simple play call on the player ensures that a load() is called once before.
To implement this logic all play() calls on the media element are replaced with a player.play() method call.

There was also another issue when you clicked on a player it starts to play only after a second click.
I figure out, that the ipad didn't fake a click event when you clicked the video element the first time. But i triggers a touchstart event. The big play button now listen on both the click and touchstart event.
