### PR TITLE
Add a mejs-fullscreen css class on the root element

### DIFF
--- a/src/css/mediaelementplayer.css
+++ b/src/css/mediaelementplayer.css
@@ -20,6 +20,11 @@
 	overflow: hidden;
 }
 
+.mejs-fullscreen {
+	/* set it to not show scroll bars so 100% will work */
+	overflow: hidden !important;
+}
+
 .mejs-container-fullscreen {
 	position: fixed;
 	left: 0;

--- a/src/js/mep-feature-fullscreen.js
+++ b/src/js/mep-feature-fullscreen.js
@@ -12,8 +12,6 @@
 
 		isNativeFullScreen: false,
 
-		docStyleOverflow: null,
-
 		isInIframe: false,
 
 		buildfullscreen: function(player, controls, layers, media) {
@@ -301,10 +299,8 @@
 				return;
 			}
 
-			// store overflow
-			docStyleOverflow = document.documentElement.style.overflow;
 			// set it to not show scroll bars so 100% will work
-			document.documentElement.style.overflow = 'hidden';
+            $(document.documentElement).addClass('mejs-fullscreen');
 
 			// store sizing
 			normalHeight = t.container.height();
@@ -436,7 +432,7 @@
 			}
 
 			// restore scroll bars to document
-			document.documentElement.style.overflow = docStyleOverflow;
+            $(document.documentElement).removeClass('mejs-fullscreen');
 
 			t.container
 				.removeClass('mejs-container-fullscreen')


### PR DESCRIPTION
This future request remove the inline overflow setting and repaced it with a class set on the root element if you switch to fullscreen mode. This gives you the ability to do additional stuff if the video is running in fullscreen. In my case i must fade a fixed navigation away. 

You may also want to add the following rule for fullscreen mode

``` css
.mejs-fullscreen * {
        /* reset all transformations, otherwise fixed elements arn't fixed to viewport */
        transform: none !important;
}
```

This fix the fullscreen for video elements that are placed in transformed elements. 
Otherwise the videos will be placed relative to the transformed element. For further reding I suggest 
http://meyerweb.com/eric/thoughts/2011/09/12/un-fixing-fixed-elements-with-css-transforms/
