### PR TITLE
fix error in method declaration of some features

### DIFF
--- a/src/js/mep-feature-backlight.js
+++ b/src/js/mep-feature-backlight.js
@@ -9,7 +9,7 @@
 	});
 
 	$.extend(MediaElementPlayer.prototype, {
-		buildbacklight = function(player, controls, layers, media) {
+		buildbacklight : function(player, controls, layers, media) {
 			if (!player.isVideo)
 				return;
 

--- a/src/js/mep-feature-playlist.js
+++ b/src/js/mep-feature-playlist.js
@@ -1,7 +1,7 @@
 (function($) {
 
 	$.extend(MediaElementPlayer.prototype, {
-		buildplaylist = function(player, controls, layers, media) {
+		buildplaylist : function(player, controls, layers, media) {
 			if (!player.isVideo)
 				return;
 


### PR DESCRIPTION
replace '=' by ':'
backlight and playlist are concerned

Signed-off-by: Eric Villard dev@eviweb.fr
