### PR TITLE
option to fix sites using HTTPS basic authentication

### DIFF
--- a/src/js/me-shim.js
+++ b/src/js/me-shim.js
@@ -92,6 +92,8 @@ mejs.MediaElementDefaults = {
 	plugins: ['flash','silverlight','youtube','vimeo'],
 	// shows debug errors on screen
 	enablePluginDebug: false,
+	// use plugin for browsers that have trouble with Basic Authentication on HTTPS sites
+	httpsBasicAuthSite: false,
 	// overrides the type specified, useful for dynamic instantiation
 	type: '',
 	// path to Flash and Silverlight plugins
@@ -262,7 +264,7 @@ mejs.HtmlMediaElementShim = {
 		
 
 		// test for native playback first
-		if (supportsMediaTag && (options.mode === 'auto' || options.mode === 'auto_plugin' || options.mode === 'native')  && !(mejs.MediaFeatures.isBustedNativeHTTPS)) {
+		if (supportsMediaTag && (options.mode === 'auto' || options.mode === 'auto_plugin' || options.mode === 'native')  && !(mejs.MediaFeatures.isBustedNativeHTTPS && options.httpsBasicAuthSite === true)) {
 						
 			if (!isMediaTag) {
 


### PR DESCRIPTION
I added a configuration option httpsBasicAuthSite to address the issue raised from https://github.com/johndyer/mediaelement/pull/845.  That change was too broad and forced Safari to use the plugins when the native HTML5 player could have worked.  This focuses the fix on the single scenario that needs it.

This option should be enabled if HTTPS basic authorization is in use on a site.  I found no good way to auto-detect this environment.

Some browsers like Safari and Android Chrome and stock browsers can't use the native HTML5 player with videos protected by HTTPS basic auth.
