### PR TITLE
Fix touch detection in QtWebKit

### DIFF
--- a/src/js/me-featuredetection.js
+++ b/src/js/me-featuredetection.js
@@ -23,7 +23,7 @@ mejs.MediaFeatures = {
 		t.isWebkit = (ua.match(/webkit/gi) !== null);
 		t.isGecko = (ua.match(/gecko/gi) !== null) && !t.isWebkit;
 		t.isOpera = (ua.match(/opera/gi) !== null);
-		t.hasTouch = ('ontouchstart' in window);
+		t.hasTouch = ('ontouchstart' in window && window.ontouchstart != null);
 		
 		// borrowed from Modernizr
 		t.svg = !! document.createElementNS &&


### PR DESCRIPTION
QtWebKit defines this property and sets it to null. This change has been made in other JS projects as well.

https://github.com/hakimel/reveal.js/pull/337 (others referenced from here too).
