### PR TITLE
More i18n fixes for compatibility with WordPress

### DIFF
--- a/src/js/me-i18n.js
+++ b/src/js/me-i18n.js
@@ -45,6 +45,7 @@
     "use strict";
     var i18n = {
         "locale": {
+            "language" : '',
             "strings" : {}
         },
         "methods" : {}
@@ -58,10 +59,12 @@
      * @see: i18n.methods.t()
      */
     i18n.locale.getLanguage = function () {
-        return i18n.locale || {
-            "language" : navigator.language
-        };
+        return i18n.locale.language || navigator.language;
     };
+
+    if ( typeof mejsL10n != 'undefined' ) {
+        i18n.locale.language = mejsL10n.language;
+    }
 
     /**
      * Store the language the locale object was initialized with
@@ -171,12 +174,12 @@
 
         if (typeof str === 'string' && str.length > 0) {
 
-            // check every time due languge can change for
+            // check every time due language can change for
             // different reasons (translation, lang switcher ..)
-            var lang = i18n.locale.getLanguage();
+            var language = i18n.locale.getLanguage();
 
             options = options || {
-                "context" : lang.language
+                "context" : language
             };
 
             return i18n.methods.t(str, args, options);
@@ -195,10 +198,10 @@
 
 ;(function(exports, undefined) {
 
-	"use strict";
+    "use strict";
 
-	if ( mejs.i18n.locale.language && mejs.i18n.locale.strings ) {
-		exports[mejs.i18n.locale.language] = mejs.i18n.locale.strings;
-	}
+    if ( typeof mejsL10n != 'undefined' ) {
+        exports[mejsL10n.language] = mejsL10n.strings;
+    };
 
 }(mejs.i18n.locale.strings));


### PR DESCRIPTION
68ce179cbd8a2426dfdeaffb1971c6783a858bd5 broke the l10n technique we used in WordPress (see #849). 

When MediaElement.js tries to use `mejs.i18n.locale.strings`, the `mejs.i18n` object is already overwritten with the one that doesn't contain the strings we're trying to add. It also doesn't detect the language we're trying to pass. See http://core.trac.wordpress.org/ticket/24183#comment:8 for reference. I've also tried to set `mejs.i18n.locale` after ME.js is loaded, but that didn't work either, it appears to be too late.

SergeyBiryukov/mediaelement@adb4c7cecd934c1f7763a14ca00f4aa9aa532b16 offers two fixes to address the issue:
- Use a separate `mejsL10n` object to pass a translation as an array of
  strings, to avoid conflicts with `mejs.i18n`.
- Make `getLanguage()` return just the language instead of the full locale
  object.
