### PR TITLE
Fix ME.js controls in RTL by forcing them to LTR

### DIFF
--- a/src/css/mediaelementplayer.css
+++ b/src/css/mediaelementplayer.css
@@ -233,6 +233,7 @@
 
 /* Start: Progress Bar */
 .mejs-controls div.mejs-time-rail {
+	direction: ltr;
 	width: 200px;
 	padding-top: 5px;
 }


### PR DESCRIPTION
Fixes #377. Needed for WordPress which has a number of RTL languages including Hebrew and Arabic.

Downstream: http://core.trac.wordpress.org/ticket/24897.
