### PR TITLE
* added 'm4a' file type, to be detected as 'audio/mp4'

### DIFF
--- a/src/js/me-shim.js
+++ b/src/js/me-shim.js
@@ -386,6 +386,7 @@ mejs.HtmlMediaElementShim = {
 		switch (ext) {
 			case 'mp4':
 			case 'm4v':
+			case 'm4a':
 				return 'mp4';
 			case 'webm':
 			case 'webma':


### PR DESCRIPTION
The current mediaelement.js implementation do not detect .m4a file type as a playable HTML5 format. This page: http://en.wikipedia.org/wiki/HTML5_Audio#Supported_audio_codecs shows that AAC is one of the supported format, and .m4a is one of the standard extension for AAC.

Because mediaelement.js do not detect it, it create the Flash component for playing. In the Chrome browser, this creates 2 simultaneous downloads of the .m4a file, one initiated by <audio> and the other by Flash. Then weird things happen as none of the components respond to mejs calls.
