### PR TITLE
Fixed IE detection

### DIFF
--- a/src/js/me-featuredetection.js
+++ b/src/js/me-featuredetection.js
@@ -17,7 +17,7 @@ mejs.MediaFeatures = {
 		t.isAndroid = (ua.match(/android/i) !== null);
 		t.isBustedAndroid = (ua.match(/android 2\.[12]/) !== null);
 		t.isBustedNativeHTTPS = (location.protocol === 'https:' && (ua.match(/android [12]\./) !== null || ua.match(/macintosh.* version.* safari/) !== null));
-		t.isIE = (nav.appName.toLowerCase().match(/trident/gi) !== null);
+		t.isIE = (nav.appName.match(/microsoft/gi) !== null) || (ua.match(/trident/gi) !== null);
 		t.isChrome = (ua.match(/chrome/gi) !== null);
 		t.isFirefox = (ua.match(/firefox/gi) !== null);
 		t.isWebkit = (ua.match(/webkit/gi) !== null);


### PR DESCRIPTION
navigator.appName is still "Microsoft Internet Explorer" for IE6-10, and "Netscape" for IE11 (so I'm told [1]), neither of which contains "trident".

Instead, combine the older "microsoft" match (which still works for IE<11) with a test for "trident" on the user agent string.

[1] http://stackoverflow.com/a/17907562
