### PR TITLE
Chromium Web Browser Support

### DIFF
--- a/src/js/me-featuredetection.js
+++ b/src/js/me-featuredetection.js
@@ -19,6 +19,7 @@ mejs.MediaFeatures = {
 		t.isBustedNativeHTTPS = (location.protocol === 'https:' && (ua.match(/android [12]\./) !== null || ua.match(/macintosh.* version.* safari/) !== null));
 		t.isIE = (nav.appName.toLowerCase().match(/trident/gi) !== null);
 		t.isChrome = (ua.match(/chrome/gi) !== null);
+		t.isChromium = (ua.match(/chromium/gi) !== null);
 		t.isFirefox = (ua.match(/firefox/gi) !== null);
 		t.isWebkit = (ua.match(/webkit/gi) !== null);
 		t.isGecko = (ua.match(/gecko/gi) !== null) && !t.isWebkit && !t.isIE;

--- a/src/js/me-shim.js
+++ b/src/js/me-shim.js
@@ -266,6 +266,12 @@ mejs.HtmlMediaElementShim = {
 			};
 		}		
 		
+		// special case for Chromium to specify natively supported video codecs (i.e. WebM and Theora) 
+		if (mejs.MediaFeatures.isChromium) { 
+			htmlMediaElement.canPlayType = function(type) { 
+				return (type.match(/video\/(webm|ogv|ogg)/gi) !== null) ? 'maybe' : ''; 
+			}; 
+		}
 
 		// test for native playback first
 		if (supportsMediaTag && (options.mode === 'auto' || options.mode === 'auto_plugin' || options.mode === 'native')  && !(mejs.MediaFeatures.isBustedNativeHTTPS && options.httpsBasicAuthSite === true)) {


### PR DESCRIPTION
I'm new to git/github, so hope what I'm doing is right...

This adds detection for the Chromium web browser, which only contains open-source video codecs (i.e. WebM and Theora). Unlike Chrome, it has no native support for MP4 files.

This is also related to a 3 year old (unresolved) issue, "Chrome vs Chromium video source confusion" https://github.com/johndyer/mediaelement/issues/62.

Feel free to improve the code, as I'm not much of the "programmer type".
