### PR TITLE
Restore IE6 compatibility

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -748,7 +748,7 @@
 			}
 
 			// detect 100% mode - use currentStyle for IE since css() doesn't return percentages
-      		if (t.height.toString().indexOf('%') > 0 || t.$node.css('max-width') === '100%' || parseInt(t.$node.css('max-width').replace(/px/,''), 10) / t.$node.offsetParent().width() === 1 || (t.$node[0].currentStyle && t.$node[0].currentStyle.maxWidth === '100%')) {
+			if (t.height.toString().indexOf('%') > 0 || t.$node.css('max-width') === '100%' || (t.$node[0].currentStyle && t.$node[0].currentStyle.maxWidth === '100%')) {
 
 				// do we have the native dimensions yet?
 				var


### PR DESCRIPTION
It seems like some recent code changes in mep-player.js broke compatibility with IE6. This line of code reverts the changes to pre-v2.12.1.

As mentioned in an earlier pull request, I'm not a coder so there might be very good reasons for the change. Perhaps there is a better way around this?
