### PR TITLE
i18n improvements

### DIFF
--- a/src/js/me-i18n-locale-de.js
+++ b/src/js/me-i18n-locale-de.js
@@ -1,7 +1,7 @@
 /*!
  * This is a i18n.locale language object.
  *
- *<de> German translation by Tim Latz, latz.tim@gmail.com
+ * German translation by Tim Latz, latz.tim@gmail.com
  *
  * @author
  *   Tim Latz (latz.tim@gmail.com)
@@ -16,11 +16,13 @@
 
     "use strict";
 
-    exports.de = {
-        "Fullscreen" : "Vollbild",
-        "Go Fullscreen" : "Vollbild an",
-        "Turn off Fullscreen" : "Vollbild aus",
-        "Close" : "Schließen"
-    };
+    if (typeof exports.de === 'undefined') {
+        exports.de = {
+            "Fullscreen" : "Vollbild",
+            "Go Fullscreen" : "Vollbild an",
+            "Turn off Fullscreen" : "Vollbild aus",
+            "Close" : "Schließen"
+        };
+    }
 
 }(mejs.i18n.locale.strings));

--- a/src/js/me-i18n-locale-zh.js
+++ b/src/js/me-i18n-locale-zh.js
@@ -1,7 +1,7 @@
 /*!
  * This is a i18n.locale language object.
  *
- *<de> Traditional chinese translation by Tim Latz, latz.tim@gmail.com
+ * Traditional chinese translation by Tim Latz, latz.tim@gmail.com
  *
  * @author
  *   Tim Latz (latz.tim@gmail.com)
@@ -16,11 +16,13 @@
 
     "use strict";
 
-    exports.zh = {
-        "Fullscreen" : "全螢幕",
-        "Go Fullscreen" : "全屏模式",
-        "Turn off Fullscreen" : "退出全屏模式",
-        "Close" : "關閉"
-    };
+    if (typeof exports.zh === 'undefined') {
+        exports.zh = {
+            "Fullscreen" : "全螢幕",
+            "Go Fullscreen" : "全屏模式",
+            "Turn off Fullscreen" : "退出全屏模式",
+            "Close" : "關閉"
+        };
+    }
 
 }(mejs.i18n.locale.strings));

--- a/src/js/me-i18n.js
+++ b/src/js/me-i18n.js
@@ -1,28 +1,24 @@
 /*!
- * Adds Internationalization and localization to objects.
+ * Adds Internationalization and localization to mediaelement.
+ *
+ * This file does not contain translations, you have to add the manually.
+ * The schema is always the same: me-i18n-locale-[ISO_639-1 Code].js
+ *
+ * Examples are provided both for german and chinese translation.
+ *
  *
  * What is the concept beyond i18n?
  *   http://en.wikipedia.org/wiki/Internationalization_and_localization
  *
- *
- * This file both i18n methods and locale which is used to translate
- * strings into other languages.
- *
- * Default translations are not available, you have to add them
- * through locale objects which are named exactly as the langcode
- * they stand for. The default language is always english (en).
+ * What langcode should i use?
+ *   http://en.wikipedia.org/wiki/ISO_639-1
  *
  *
- * Wrapper built to be able to attach the i18n object to
- * other objects without changing more than one line.
- *
- *
- * LICENSE:
+ * License?
  *
  *   The i18n file uses methods from the Drupal project (drupal.js):
  *     - i18n.methods.t() (modified)
  *     - i18n.methods.checkPlain() (full copy)
- *     - i18n.methods.formatString() (full copy)
  *
  *   The Drupal project is (like mediaelementjs) licensed under GPLv2.
  *    - http://drupal.org/licensing/faq/#q1
@@ -33,8 +29,6 @@
  * @author
  *   Tim Latz (latz.tim@gmail.com)
  *
- * @see
- *   me-i18n-locale.js
  *
  * @params
  *  - context - document, iframe ..
@@ -54,22 +48,19 @@
 
 
     /**
-     * Get the current browser's language
-     *
-     * @see: i18n.methods.t()
+     * Get language, fallback to browser's language if empty
      */
-    i18n.locale.getLanguage = function () {
-        return i18n.locale.language || navigator.language;
+    i18n.getLanguage = function () {
+        var language = i18n.locale.language || window.navigator.userLanguage || window.navigator.language;
+        // convert to iso 639-1 (2-letters, lower case)
+        return language.substr(0, 2).toLowerCase();
     };
 
+    // i18n fixes for compatibility with WordPress
     if ( typeof mejsL10n != 'undefined' ) {
         i18n.locale.language = mejsL10n.language;
     }
 
-    /**
-     * Store the language the locale object was initialized with
-     */
-    i18n.locale.INIT_LANGUAGE = i18n.locale.getLanguage();
 
 
     /**
@@ -94,73 +85,27 @@
     };
 
     /**
-     * Replace placeholders with sanitized values in a string.
-     *
-     * @param str
-     *   A string with placeholders.
-     * @param args
-     *   An object of replacements pairs to make. Incidences of any key in this
-     *   array are replaced with the corresponding value. Based on the first
-     *   character of the key, the value is escaped and/or themed:
-     *    - !variable: inserted as is
-     *    - @variable: escape plain text to HTML (i18n.methods.checkPlain)
-     *    - %variable: escape text and theme as a placeholder for user-submitted
-     *      content (checkPlain + <em class="placeholder" > )
-     *
-     * @see i18n.methods.t()
-     */
-    i18n.methods.formatString = function(str, args) {
-        // Transform arguments before inserting them.
-        for (var key in args) {
-            switch (key.charAt(0)) {
-                // Escaped only.
-                case '@':
-                    args[key] = i18n.methods.checkPlain(args[key]);
-                    break;
-                // Pass-through.
-                case '!':
-                    break;
-                // Escaped and placeholder.
-                case '%':
-                default:
-                    args[key] = '<em class="placeholder">' + i18n.methods.checkPlain(args[key]) + '</em>';
-                    break;
-            }
-            str = str.replace(key, args[key]);
-        }
-        return str;
-    };
-
-    /**
      * Translate strings to the page language or a given language.
      *
-     * See the documentation of the server-side t() function for further details.
      *
      * @param str
      *   A string containing the English string to translate.
-     * @param args
-     *   An object of replacements pairs to make after translation. Incidences
-     *   of any key in this array are replaced with the corresponding value.
-     *   See i18n.methods.formatString().
      *
      * @param options
      *   - 'context' (defaults to the default context): The context the source string
      *     belongs to.
      *
      * @return
-     *   The translated string.
+     *   The translated string, escaped via i18n.methods.checkPlain()
      */
-    i18n.methods.t = function (str, args, options) {
+    i18n.methods.t = function (str, options) {
 
         // Fetch the localized version of the string.
         if (i18n.locale.strings && i18n.locale.strings[options.context] && i18n.locale.strings[options.context][str]) {
             str = i18n.locale.strings[options.context][str];
         }
 
-        if (args) {
-            str = i18n.methods.formatString(str, args);
-        }
-        return str;
+        return i18n.methods.checkPlain(str);
     };
 
 
@@ -170,25 +115,25 @@
      * @see i18n.methods.t()
      * @throws InvalidArgumentException
      */
-    i18n.t = function(str, args, options) {
+    i18n.t = function(str, options) {
 
         if (typeof str === 'string' && str.length > 0) {
 
             // check every time due language can change for
             // different reasons (translation, lang switcher ..)
-            var language = i18n.locale.getLanguage();
+            var language = i18n.getLanguage();
 
             options = options || {
                 "context" : language
             };
 
-            return i18n.methods.t(str, args, options);
+            return i18n.methods.t(str, options);
         }
         else {
             throw {
                 "name" : 'InvalidArgumentException',
                 "message" : 'First argument is either not a string or empty.'
-            }
+            };
         }
     };
 
@@ -196,12 +141,13 @@
     exports.i18n = i18n;
 }(document, mejs));
 
+// i18n fixes for compatibility with WordPress
 ;(function(exports, undefined) {
 
     "use strict";
 
     if ( typeof mejsL10n != 'undefined' ) {
         exports[mejsL10n.language] = mejsL10n.strings;
-    };
+    }
 
 }(mejs.i18n.locale.strings));


### PR DESCRIPTION
Features added / changed:
- i18n support for [ISO 693_1](http://en.wikipedia.org/wiki/ISO_639-1)
- i18n.getLanguage() Internet Explorer language detection
- i18n.t() converts special chars to html entities (like mejs.Utility.escapeHTML)
- commented lines, fixed some typos
- locale files (german, traditional chinese) check if the langcode is not already set

The last point is related to pull request [850](https://github.com/johndyer/mediaelement/pull/850) and [940](https://github.com/johndyer/mediaelement/pull/940), both targeting i18n + Wordpress. I think checking prerequisites is a good idea, therefore my own locale files do not overwrite existing locale objects anymore.

You have to run Builder.py manually to create the *min.js files. No Java on my machine :)
