### PR TITLE
Quick fix for a potential problem where node.parentNode is undefined.

### DIFF
--- a/src/js/me-shim.js
+++ b/src/js/me-shim.js
@@ -452,7 +452,7 @@ mejs.HtmlMediaElementShim = {
 		// check for placement inside a <p> tag (sometimes WYSIWYG editors do this)
 		node = htmlMediaElement.parentNode;
 		while (node !== null && node.tagName.toLowerCase() != 'body') {
-			if (node.parentNode.tagName.toLowerCase() == 'p') {
+			if (node.parentNode && node.parentNode.tagName.toLowerCase() == 'p') {
 				node.parentNode.parentNode.insertBefore(node, node.parentNode);
 				break;
 			}


### PR DESCRIPTION
Howdy there--I was working on an app that used mediaelementjs, and sometimes in Firefox I was seeing an error on this line where it was reaching into `node.parentNode`. For whatever reason, `node.parentNode` was undefined in these instances.

This guards against throwing an un-handled exception in that case.
