### PR TITLE
Fix fullscreen iframe zoom bug.

### DIFF
--- a/src/js/mep-feature-fullscreen.js
+++ b/src/js/mep-feature-fullscreen.js
@@ -320,9 +320,16 @@
 						setTimeout(function checkFullscreen() {
 
 							if (t.isNativeFullScreen) {
+								var zoomMultiplier = window["devicePixelRatio"] || 1;
+								// Use a percent error margin since devicePixelRatio is a float and not exact.
+								var percentErrorMargin = 0.002; // 0.2%
+								var windowWidth = zoomMultiplier * $(window).width();
+								var screenWidth = screen.width;
+								var absDiff = Math.abs(screenWidth - windowWidth);
+								var marginError = screenWidth * percentErrorMargin;
 
 								// check if the video is suddenly not really fullscreen
-								if ($(window).width() !== screen.width) {
+								if (absDiff > marginError) {
 									// manually exit
 									t.exitFullScreen();
 								} else {


### PR DESCRIPTION
To reproduce:
- On chrome, zoom browser on a mediaelement in an iframe.
- Go in fullscreen
- Full screen will be exited immediately

The fix:
- Use window.devicePixelRatio for zoom ratio.
- When fullscreen, calculate window width with devicePixelRatio taken into account
