### PR TITLE
Bug fix: Make sure we calculate correctly the video player height

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -755,6 +755,11 @@
 					parentWidth = t.container.parent().closest(':visible').width(),
 					newHeight = t.isVideo || !t.options.autosizeProgress ? parseInt(parentWidth * nativeHeight/nativeWidth, 10) : nativeHeight;
 
+				// When we use percent, the newHeight can't be calculated so we get the container height
+				if(isNaN(newHeight)) {
+					newHeight = t.container.parent().closest(':visible').height();
+				}
+
 				if (t.container.parent()[0].tagName.toLowerCase() === 'body') { // && t.container.siblings().count == 0) {
 					parentWidth = $(window).width();
 					newHeight = $(window).height();


### PR DESCRIPTION
If we want the video player get the same size of its container we set defaultVideoWidth and defaultVideoHeight to 100%. In that case the calculation of newHeight is not correct, so we get the container height
