### PR TITLE
Volume control is incorrectly hidden on Chromebook Pixel

### DIFF
--- a/src/js/mep-feature-volume.js
+++ b/src/js/mep-feature-volume.js
@@ -12,7 +12,7 @@
 		buildvolume: function(player, controls, layers, media) {
 				
 			// Android and iOS don't support volume controls
-			if (mejs.MediaFeatures.hasTouch && this.options.hideVolumeOnTouchDevices)
+			if ((mejs.MediaFeatures.isAndroid || mejs.MediaFeatures.isiOS) && this.options.hideVolumeOnTouchDevices)
 				return;
 			
 			var t = this,


### PR DESCRIPTION
The Chromebook Pixel has a touchscreen, but is a laptop rather than a smartphone or tablet. The logic that decides whether the volume control is displayed or not should therefore not depend on whether a touchscreen is present, but instead test for iOS or Android. (I'm not clear how this would affect Windows 8 PCs and tablets)
