### PR TITLE
restore focus after click on the controls

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -1021,11 +1021,9 @@
 						return true;
 				});
 
-				// check if someone clicked outside a player region, then kill its focus
+				// check if someone clicked outside a player region, then kill its focus and vise versa
 				t.globalBind('click', function(event) {
-						if ($(event.target).closest('.mejs-container').length == 0) {
-								player.hasFocus = false;
-						}
+					player.hasFocus = $(event.target).closest('.mejs-container').length != 0;
 				});
 
 		},


### PR DESCRIPTION
Focus is removed when someone clicked outside a player region. The only way to restore the focus is pause/play. That is not always convenient. This patch allows restore focus after click on the controls.
