### PR TITLE
Fix layout bug when zooming page

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -842,7 +842,7 @@
 			// outer area
 			rail.width(railWidth);
 			// dark space
-			total.width(railWidth - (total.outerWidth(true) - total.width()));
+			total.width(railWidth - (total.outerWidth(true) - total.width()) - 1);
 
 			if (t.setProgressRail)
 				t.setProgressRail();


### PR DESCRIPTION
When zooming the page, some of the controls get messed.
See [mediaelement.js volume control messed when increasing browser zoom](http://stackoverflow.com/questions/17272328/mediaelement-js-volume-control-messed-when-increasing-browser-zoom).

Simply decrese 1 pixel for `div.mejs-time-rail` can avoid the layout overflow.
