### PR TITLE
Fixed the reference to `media` in the bigPlay control creation.

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -922,7 +922,7 @@
 				.bind('click touchstart', function() {
 					if (t.options.clickToPlayPause) {
 						if (media.paused) {
-							t.play();
+							media.play();
 						}
 					}
 				});


### PR DESCRIPTION
The existing reference was causing the following scenario, **on first load**, in both html5 and flash:
1. Load page with player (http://mediaelementjs.com).
2. On the bottom control bar, press the "Play" button, allow the movie playhead to advance, note the time.
3. On the bottom control bar, press the "Pause" button.
4. Click on the big play button or the overlay that contains it.
5. The player will reload the video and play it from 0. In Flash in IE8 it will reset to 0 and not play.

After the fix, it works as expected in html5, Flash and Flash IE8.
