### PR TITLE
Function remove() should remove mejs container only if it exists

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -1126,7 +1126,9 @@
 			// Remove the player from the mejs.players object so that pauseOtherPlayers doesn't blow up when trying to pause a non existance flash api.
 			delete mejs.players[t.id];
 
-			t.container.remove();
+			if (typeof t.container == 'object') {
+				t.container.remove();
+			}
 			t.globalUnbind();
 			delete t.node.player;
 		}


### PR DESCRIPTION
In case of mobile clients (iPad, iPhone and Android) and usage of the
native controls (options iPadUseNativeControls, iPhoneUseNativeControls
and AndroidUseNativeControls) t.container does not exist. In this case
the container may not exist but is implicitly removed in remove().
