### PR TITLE
[PR] Add Gruntfile.js and package.json for local builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build/SilverlightMediaElement.dll
 tests/*
 newfeatures/*
 /mejs3/
+node_modules
+local-build

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,88 @@
+module.exports = function(grunt) {
+
+    grunt.loadNpmTasks('grunt-contrib-uglify');
+    grunt.loadNpmTasks('grunt-contrib-concat');
+    grunt.loadNpmTasks('grunt-contrib-copy');
+    grunt.loadNpmTasks('grunt-contrib-cssmin');
+    
+    grunt.initConfig({
+        pkg: grunt.file.readJSON('package.json'),
+        concat: {
+            me: {
+                src: [
+                    'src/js/me-header.js',
+                    'src/js/me-namespace.js',
+                    'src/js/me-utility.js',
+                    'src/js/me-plugindetector.js',
+                    'src/js/me-featuredetection.js',
+                    'src/js/me-mediaelements.js',
+                    'src/js/me-shim.js',
+                    'src/js/me-i18n.js',
+                    'src/js/me-i18n-locale-de.js',
+                    'src/js/me-i18n-locale-zh.js'
+                ],
+                dest: 'local-build/mediaelement.js'
+            },
+            mep: {
+                src: [
+                    'src/js/mep-header.js',
+                    'src/js/mep-library.js',
+                    'src/js/mep-player.js',
+                    'src/js/mep-feature-playpause.js',
+                    'src/js/mep-feature-stop.js',
+                    'src/js/mep-feature-progress.js',
+                    'src/js/mep-feature-time.js',
+                    'src/js/mep-feature-volume.js',
+                    'src/js/mep-feature-fullscreen.js',
+                    'src/js/mep-feature-tracks.js',
+                    'src/js/mep-feature-contextmenu.js',
+                    'src/js/mep-feature-postroll.js'
+                ],
+                dest: 'local-build/mediaelementplayer.js'
+            },
+            bundle: {
+                src: [
+                    'local-build/mediaelement.js',
+                    'local-build/mediaelementplayer.js'
+                ],
+                dest: 'local-build/mediaelement-and-player.js'
+            }
+        },
+        uglify: {
+            me: {
+                src    : ['local-build/mediaelement.js'],
+                dest   : 'local-build/mediaelement.min.js',
+                banner : 'src/js/me-header.js'
+            },
+            mep: {
+                src    : ['local-build/mediaelementplayer.js'],
+                dest   : 'local-build/mediaelementplayer.min.js',
+                banner : 'src/js/mep-header.js'
+            },
+            bundle: {
+                src  : ['local-build/mediaelement-and-player.js'],
+                dest : 'local-build/mediaelement-and-player.min.js'
+            }
+        },
+        cssmin: {
+            build: {
+                src  : ['src/css/mediaelementplayer.css'],
+                dest : 'local-build/mediaelementplayer.min.css'
+            }
+        },
+        copy: {
+            build: {
+                expand  : true,
+                cwd     : 'src/css/',
+                src     : ['*.png', '*.svg', '*.gif', '*.css'],
+                dest    : 'local-build/',
+                flatten : true,
+                filter  : 'isFile'
+            }
+        }
+    });
+
+    
+    grunt.registerTask('default', ['concat', 'uglify', 'cssmin', 'copy']);
+
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "mediaelement",
+  "version": "2.14.0",
+  "devDependencies": {
+    "grunt": "~0.4.1",
+    "grunt-contrib-uglify": "~0.2.2",
+    "grunt-contrib-concat": "~0.3.0",
+    "grunt-contrib-cssmin": "~0.6.1",
+    "grunt-contrib-copy": "~0.4.1"
+  }
+}


### PR DESCRIPTION
This is pretty much a direct copy of the PR in #971, which I think still does the trick, but uses the `build` directory.

I've changed the Grunt build directory to use 'local-build' instead so that it does not conflict with the build directory used by the project to provide these files.

I attempted to match the JS concatenaton done in Builder.py, and the local build has worked as expected so far.

Thanks for this project!
