### PR TITLE
Adding width and height to .me-plugin

### DIFF
--- a/src/css/mediaelementplayer.css
+++ b/src/css/mediaelementplayer.css
@@ -9,6 +9,8 @@
 
 .me-plugin {
 	position: absolute;
+	height: 0;
+	width: 0;
 }
 
 .mejs-embed, .mejs-embed body {


### PR DESCRIPTION
Even with position: absolute, IE8 was leaving a gap for the plug-in in
my layout. I attempted to solve this by giving the element display:
none, but that resulted in IE8 throwing "object does not support
property or method" errors. Applying 0 values for width and height
solved my layout issue without breaking IE8.
