### PR TITLE
Fix for silverlight issue with fullscreen button

### DIFF
--- a/build/mediaelement-and-player.js
+++ b/build/mediaelement-and-player.js
@@ -562,14 +562,24 @@ mejs.PluginMediaElement.prototype = {
 	},
 	
 	positionFullscreenButton: function(x,y,visibleAndAbove) {
-		if (this.pluginApi != null && this.pluginApi.positionFullscreenButton) {
-			this.pluginApi.positionFullscreenButton(x,y,visibleAndAbove);
+		if (this.pluginApi != null) {
+			//cannot test for pluginApi.positionFullscreenButton because of "Invalid InvokeType" error
+			//so justr try and call it
+			try {
+				this.pluginApi.positionFullscreenButton(x,y,visibleAndAbove);	
+			}
+			catch(e) {}
 		}
 	},
 	
 	hideFullscreenButton: function() {
-		if (this.pluginApi != null && this.pluginApi.hideFullscreenButton) {
-			this.pluginApi.hideFullscreenButton();
+		if (this.pluginApi != null && this.pluginApi) {
+			//cannot test for pluginApi.hideFullscreenButton because of "Invalid InvokeType" error
+			//so justr try and call it
+			try {
+				this.pluginApi.hideFullscreenButton();
+			}
+			catch(e) {}
 		}		
 	},	
 	


### PR DESCRIPTION
When using silverlight the test:
if (this.pluginApi != null && this.pluginApi.positionFullscreenButton)

fails because of an "Invalid InvokeType for this operation" error. Simply calling the function and catching it if it fails fixes this issue.
