### PR TITLE
Fix for silverlight issue with fullscreen button

### DIFF
--- a/src/js/me-mediaelements.js
+++ b/src/js/me-mediaelements.js
@@ -163,15 +163,23 @@ mejs.PluginMediaElement.prototype = {
 	},
 	
 	positionFullscreenButton: function(x,y,visibleAndAbove) {
-		if (this.pluginApi != null && this.pluginApi.positionFullscreenButton) {
-			this.pluginApi.positionFullscreenButton(x,y,visibleAndAbove);
-		}
+		if (this.pluginApi != null) {
+	        	//cannot test for pluginApi.positionFullscreenButton because of "Invalid InvokeType" error
+            		//so just try and call it
+            		try {
+                    	this.pluginApi.positionFullscreenButton(x,y,visibleAndAbove);	
+            		}
+	        	catch (e) { }
+	    	}
 	},
 	
 	hideFullscreenButton: function() {
-		if (this.pluginApi != null && this.pluginApi.hideFullscreenButton) {
-			this.pluginApi.hideFullscreenButton();
-		}		
+		//cannot test for pluginApi.hideFullscreenButton because of "Invalid InvokeType" error
+            	//so just try and call it
+            	try {
+	        	this.pluginApi.hideFullscreenButton();
+            	}
+	        catch(e) {}		
 	},	
 	
 


### PR DESCRIPTION
When using silverlight hovering over the fullscreen button throws an "Invalid InvokeType" because we cannot check for the function by checking "this.pluginApi.positionFullscreenButton", so simply try and call the function.
