### PR TITLE
Removed "touchstart" to prevent Android issues

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -941,7 +941,7 @@
 					'<div class="mejs-overlay-button"></div>'+
 				'</div>')
 				.appendTo(layers)
-				.bind('click', function() {
+				.bind('click', function() {  // Removed 'touchstart' due issues on Samsung Android devices where a tap on bigPlay started and immediately stopped the video
 					if (t.options.clickToPlayPause) {
 						if (media.paused) {
 							media.play();


### PR DESCRIPTION
Removed "touchstart" event in order to overcome some android 4.1-4.3
issues (samsung devices) where the click on the bigPlay area fired two
events. The player started playing and immediatly paused again. I don't
know if that will have any side effects. I testet various mobile devices
sucessfully.
