### PR TITLE
Option `setDimensions` to allow deactivation of inline widths and heights at player elements

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -341,34 +341,33 @@
 					capsTagName = tagType.substring(0,1).toUpperCase() + tagType.substring(1);
 
 
-				if( t.options.setDimensions ) {
-					if (t.options[tagType + 'Width'] > 0 || t.options[tagType + 'Width'].toString().indexOf('%') > -1) {
-						t.width = t.options[tagType + 'Width'];
-					} else if (t.media.style.width !== '' && t.media.style.width !== null) {
-						t.width = t.media.style.width;
-					} else if (t.media.getAttribute('width') !== null) {
-						t.width = t.$media.attr('width');
-					} else {
-						t.width = t.options['default' + capsTagName + 'Width'];
-					}
 
-					if (t.options[tagType + 'Height'] > 0 || t.options[tagType + 'Height'].toString().indexOf('%') > -1) {
-						t.height = t.options[tagType + 'Height'];
-					} else if (t.media.style.height !== '' && t.media.style.height !== null) {
-						t.height = t.media.style.height;
-					} else if (t.$media[0].getAttribute('height') !== null) {
-						t.height = t.$media.attr('height');
-					} else {
-						t.height = t.options['default' + capsTagName + 'Height'];
-					}
-
-					// set the size, while we wait for the plugins to load below
-					t.setPlayerSize(t.width, t.height);
-
-					// create MediaElementShim
-					meOptions.pluginWidth = t.width;
-					meOptions.pluginHeight = t.height;
+				if (t.options[tagType + 'Width'] > 0 || t.options[tagType + 'Width'].toString().indexOf('%') > -1) {
+					t.width = t.options[tagType + 'Width'];
+				} else if (t.media.style.width !== '' && t.media.style.width !== null) {
+					t.width = t.media.style.width;
+				} else if (t.media.getAttribute('width') !== null) {
+					t.width = t.$media.attr('width');
+				} else {
+					t.width = t.options['default' + capsTagName + 'Width'];
 				}
+
+				if (t.options[tagType + 'Height'] > 0 || t.options[tagType + 'Height'].toString().indexOf('%') > -1) {
+					t.height = t.options[tagType + 'Height'];
+				} else if (t.media.style.height !== '' && t.media.style.height !== null) {
+					t.height = t.media.style.height;
+				} else if (t.$media[0].getAttribute('height') !== null) {
+					t.height = t.$media.attr('height');
+				} else {
+					t.height = t.options['default' + capsTagName + 'Height'];
+				}
+
+				// set the size, while we wait for the plugins to load below
+				t.setPlayerSize(t.width, t.height);
+
+				// create MediaElementShim
+				meOptions.pluginWidth = t.width;
+				meOptions.pluginHeight = t.height;
 			}
 
 			// create MediaElement shim
@@ -768,6 +767,10 @@
 
 		setPlayerSize: function(width,height) {
 			var t = this;
+
+			if( !t.options.setDimensions ) {
+				return false;
+			}
 
 			if (typeof width != 'undefined') {
 				t.width = width;


### PR DESCRIPTION
Currently the setting of widths and heights to the player is somehow broken, as one can't set values of `100%`.

I favor to set widths and heights for multiple players via CSS (and using media queries) instead of setting them later via JS. I've added the option `setDimensions` which has a default value of `true`. The option `setDimensions` is set to `true` per defautl to allow backwards compatibility. One may set this option to `false` to disable any inline styles for widths and heights.

commit message: “mep-player.js: add option (setDimensions) to disable the setting of widths and heights through JS, since there was no way to have a fluid player width and height (i.e. set to 100% each)”
