### PR TITLE
Make mejs.MediaFeatures.isFullScreen() more consistent

### DIFF
--- a/src/js/me-featuredetection.js
+++ b/src/js/me-featuredetection.js
@@ -85,13 +85,13 @@ mejs.MediaFeatures = {
 			}
 			
 			t.isFullScreen = function() {
-				if (v.mozRequestFullScreen) {
+				if (t.hasMozNativeFullScreen) {
 					return d.mozFullScreen;
 				
-				} else if (v.webkitRequestFullScreen) {
+				} else if (t.hasWebkitNativeFullScreen) {
 					return d.webkitIsFullScreen;
 				
-				} else if (v.hasMsNativeFullScreen) {
+				} else if (t.hasMsNativeFullScreen) {
 					return d.msFullscreenElement !== null;
 				}
 			}


### PR DESCRIPTION
This is more consistent with how the other helpers look, and also
looks for hasMsNativeFullScreen on the correct object.
