### PR TITLE
Always listen for the fullscreenchange event on the document

### DIFF
--- a/src/js/mep-feature-fullscreen.js
+++ b/src/js/mep-feature-fullscreen.js
@@ -40,11 +40,7 @@
 					}
 				};
 
-				if (mejs.MediaFeatures.hasMozNativeFullScreen) {
-					player.globalBind(mejs.MediaFeatures.fullScreenEventName, func);
-				} else {
-					player.container.bind(mejs.MediaFeatures.fullScreenEventName, func);
-				}
+				player.globalBind(mejs.MediaFeatures.fullScreenEventName, func);
 			}
 
 			var t = this,


### PR DESCRIPTION
The only event that is fired on the element is the
webkitfullscreenchange event. The mozfullscreenchange and
MSFullscreenChange events fire on the document, which is also true of
the unprefixed fullscreenchange event per spec:
http://fullscreen.spec.whatwg.org/#go-fullscreen

Because the webkitfullscreenchange event bubbles, it still works to
add the listener to the document, so just do that everywhere.
