### PR TITLE
The hours are not required on the webvtt format

### DIFF
--- a/src/js/mep-feature-tracks.js
+++ b/src/js/mep-feature-tracks.js
@@ -556,7 +556,7 @@
 		webvvt: {
 			// match start "chapter-" (or anythingelse)
 			pattern_identifier: /^([a-zA-z]+-)?[0-9]+$/,
-			pattern_timecode: /^([0-9]{2}:[0-9]{2}:[0-9]{2}([,.][0-9]{1,3})?) --\> ([0-9]{2}:[0-9]{2}:[0-9]{2}([,.][0-9]{3})?)(.*)$/,
+			pattern_timecode: /^(([0-9]{2}:)?[0-9]{2}:[0-9]{2}([,.][0-9]{1,3})?) --\> (([0-9]{2}:)?[0-9]{2}:[0-9]{2}([,.][0-9]{3})?)(.*)$/,
 
 			parse: function(trackText) {
 				var 
@@ -567,30 +567,25 @@
 					text;
 				for(; i<lines.length; i++) {
 					// check for the line number
-					if (this.pattern_identifier.exec(lines[i])){
-						// skip to the next line where the start --> end time code should be
+					timecode = this.pattern_timecode.exec(lines[i]);
+					if (timecode && i<lines.length){
 						i++;
-						timecode = this.pattern_timecode.exec(lines[i]);				
-
-						if (timecode && i<lines.length){
+						// grab all the (possibly multi-line) text that follows
+						text = lines[i];
+						i++;
+						while(lines[i] !== '' && i<lines.length){
+							text = text + '\n' + lines[i];
 							i++;
-							// grab all the (possibly multi-line) text that follows
-							text = lines[i];
-							i++;
-							while(lines[i] !== '' && i<lines.length){
-								text = text + '\n' + lines[i];
-								i++;
-							}
-							text = $.trim(text).replace(/(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig, "<a href='$1' target='_blank'>$1</a>");
-							// Text is in a different array so I can use .join
-							entries.text.push(text);
-							entries.times.push(
-							{
-								start: (mejs.Utility.convertSMPTEtoSeconds(timecode[1]) == 0) ? 0.200 : mejs.Utility.convertSMPTEtoSeconds(timecode[1]),
-								stop: mejs.Utility.convertSMPTEtoSeconds(timecode[3]),
-								settings: timecode[5]
-							});
 						}
+						text = $.trim(text).replace(/(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig, "<a href='$1' target='_blank'>$1</a>");
+						// Text is in a different array so I can use .join
+						entries.text.push(text);
+						entries.times.push(
+						{
+							start: (mejs.Utility.convertSMPTEtoSeconds(timecode[1]) == 0) ? 0.200 : mejs.Utility.convertSMPTEtoSeconds(timecode[1]),
+							stop: mejs.Utility.convertSMPTEtoSeconds(timecode[4]),
+							settings: timecode[7]
+						});
 					}
 				}
 				return entries;


### PR DESCRIPTION
According to http://dev.w3.org/html5/webvtt/ the hours are not required on the webvtt format.

Just make it optional in the regex and update the index in the code.
Also the line with the 'number' before the time is not required.

So support 4 combination of webvtt format: 

1)
00:11.000 --> 00:13.000
<v Roger Bingham>We are in New York City

2)
1
00:11.000 --> 00:13.000
<v Roger Bingham>We are in New York City

3)
00:00:11.000 --> 00:00:13.000
<v Roger Bingham>We are in New York City

4)
1
00:00:11.000 --> 00:00:13.000
<v Roger Bingham>We are in New York City
