### PR TITLE
Fix #1071: Add main property to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,5 +18,9 @@
     "!/build/**",
     "!/bower.json",
     "!/README*"
+  ],
+  "main": [
+    "./build/mediaelement-and-player.js",
+    "./build/mediaelementplayer.css"
   ]
 }


### PR DESCRIPTION
Adds the missing `main` property needed by tools liked grunt-wiredep for injecting the required files into a project mentioned in issue #1071. The rest of the recommended changes have already been made.
