### PR TITLE
Fix #1246. Captions start language is not ticked in Firefox

### DIFF
--- a/src/js/mep-feature-tracks.js
+++ b/src/js/mep-feature-tracks.js
@@ -265,7 +265,7 @@
 
 			// auto select
 			if (t.options.startLanguage == lang) {
-				$('#' + t.id + '_captions_' + lang).click();
+				$('#' + t.id + '_captions_' + lang).prop('checked', true).trigger('click');
 			}
 
 			t.adjustLanguageBox();


### PR DESCRIPTION
See #1246. Also, test the following in Firefox and in other browsers: http://jsfiddle.net/mE3xb/2/
Firefox has some weird and inconsistent behavior with jquery .click()
Changing in src/js/mep-feature-tracks.js

```
$('#' + t.id + '_captions_' + lang).click();
```

to

```
$('#' + t.id + '_captions_' + lang).prop('checked', true).trigger('click');
```

fixes this and should work for all browsers too.
