### PR TITLE
Remove video-only restriction on playback speed feature

### DIFF
--- a/src/js/mep-feature-speed.js
+++ b/src/js/mep-feature-speed.js
@@ -12,9 +12,6 @@
 	$.extend(MediaElementPlayer.prototype, {
 
 		buildspeed: function(player, controls, layers, media) {
-			if (!player.isVideo)
-				return;
-
 			var t = this;
 
 			if (t.media.pluginType == 'native') {


### PR DESCRIPTION
The playback speed controls work wonderfully on audio as well!
