### PR TITLE
Fix nativeWidth() to return defaultAudioWidth

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -794,7 +794,7 @@
 							return t.options.defaultVideoWidth;
 						}
 					} else {
-						return t.options.defaultAudioHeight;
+						return t.options.defaultAudioWidth;
 					}
 				})();
 


### PR DESCRIPTION
nativeWidth() was returning defaultAudioHeight instead of defaultAudioWidth on <audio> elements
