### PR TITLE
Don't set .me-plugin width/height to 0

### DIFF
--- a/src/css/mediaelementplayer.css
+++ b/src/css/mediaelementplayer.css
@@ -9,8 +9,8 @@
 
 .me-plugin {
 	position: absolute;
-	height: 0;
-	width: 0;
+	height: auto;
+	width: auto;
 }
 
 .mejs-embed, .mejs-embed body {


### PR DESCRIPTION
While testing 2.15.0 for upgrade in WordPress, I noticed that all video files played by a plugin were only outputting audio, no video. Reverting https://github.com/johndyer/mediaelement/commit/53810f573dd7b16693e5d5a2cfa4375e4542935e returned playback to normal. In lieu of reverting, these values can just be changed to `auto`, so that the fix for IE8 will remain.
