### PR TITLE
Fix for bugs caused by #1055

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -814,11 +814,12 @@
 
 				var
 					parentWidth = t.container.parent().closest(':visible').width(),
-					newHeight = t.isVideo || !t.options.autosizeProgress ? parseInt(parentWidth * nativeHeight/nativeWidth, 10) > t.container.parent().closest(':visible').height() ? t.container.parent().closest(':visible').height() : parseInt(parentWidth * nativeHeight/nativeWidth, 10) : nativeHeight;
+					parentHeight = t.container.parent().closest(':visible').height(),
+					newHeight = t.isVideo || !t.options.autosizeProgress ? parseInt(parentWidth * nativeHeight/nativeWidth, 10) : nativeHeight;
 
 				// When we use percent, the newHeight can't be calculated so we get the container height
-				if(isNaN(newHeight)) {
-					newHeight = t.container.parent().closest(':visible').height();
+				if(isNaN(newHeight) || ( parentHeight != 0 && newHeight > parentHeight )) {
+					newHeight = parentHeight;
 				}
 
 				if (t.container.parent()[0].tagName.toLowerCase() === 'body') { // && t.container.siblings().count == 0) {


### PR DESCRIPTION
Hi, 

This PR keeps PR #1055, but adds a work around for zero height containers.
When a video has width: 100%; height: 100%; on its style attribute, like on the code below the container's height would be zero.
`<video width="1920" height="1080" style="width: 100%; height:100%;">`

This PR fixes this by checking if the parent height is not zero before assigning it as the calculated height.

Thanks!
