### PR TITLE
mep-feature-ads: Link overlay only when url is given

### DIFF
--- a/src/js/mep-feature-ads.js
+++ b/src/js/mep-feature-ads.js
@@ -193,8 +193,8 @@
 			t.hideControls();
 			
 			// enable clicking through
-			t.adsLayer.show();
 			if (t.options.adsPrerollAdUrl != '') {
+				t.adsLayer.show();
 				t.adsLayer.find('a').attr('href', t.options.adsPrerollAdUrl);
 			}
 			


### PR DESCRIPTION
view adsLayer only when the AdUrl is not empty, to have normal Play/Pause behaviour when AdUrl is empty
