### PR TITLE
Add task to remove console.log (see #1147 & #1243)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,6 +4,7 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-contrib-concat');
     grunt.loadNpmTasks('grunt-contrib-copy');
     grunt.loadNpmTasks('grunt-contrib-cssmin');
+    grunt.loadNpmTasks("grunt-remove-logging");
 
     grunt.initConfig({
         pkg: grunt.file.readJSON('package.json'),
@@ -49,6 +50,19 @@ module.exports = function(grunt) {
                 dest: 'local-build/mediaelement-and-player.js'
             }
         },
+        removelogging: {
+            dist: {
+                src: [
+                    'local-build/mediaelement.js',
+                    'local-build/mediaelementplayer.js',
+                    'local-build/mediaelement-and-player.js'
+                ]
+            },
+            options: {
+                // Keep `warn` and other methods from the console API
+                methods: ['log']
+            }
+        },
         uglify: {
             me: {
                 src    : ['local-build/mediaelement.js'],
@@ -84,6 +98,6 @@ module.exports = function(grunt) {
     });
 
 
-    grunt.registerTask('default', ['concat', 'uglify', 'cssmin', 'copy']);
+    grunt.registerTask('default', ['concat', 'removelogging', 'uglify', 'cssmin', 'copy']);
 
 };

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "grunt-contrib-uglify": "~0.2.2",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-cssmin": "~0.6.1",
-    "grunt-contrib-copy": "~0.4.1"
+    "grunt-contrib-copy": "~0.4.1",
+    "grunt-remove-logging": "~0.2.0"
   }
 }


### PR DESCRIPTION
Added a new Grunt task to the build process to remove `console.log` statements. This is important for production since, in some versions of IE, the `console` object is only created after opening the Dev Tools.

Other calls like `console.warn` are kept since they may be useful in production. An e.g. from the source:

``` javascript
console.warn("You need to include froogaloop for vimeo to work");
```

This doesn't update the `build` dir because files were already different when I ran `grunt` on the master. But I can add that if you want. Thanks for this great project :+1:
