### PR TITLE
Add repository field to package.json to avoid warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "mediaelement",
   "version": "2.14.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/johndyer/mediaelement.git"
+  },
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-uglify": "~0.2.2",


### PR DESCRIPTION
This just adds the repository field to the `package.json` file. This prevents warnings when developers run `npm install` in this project or in any other project that has `mediaelement` as a dependency:

```
npm WARN package.json: No repository field
```
