### PR TITLE
Fix IE8 error on window resizing

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -827,7 +827,7 @@
 					newHeight = $(window).height();
 				}
 
-				if ( newHeight != 0 && parentWidth != 0 ) {
+				if ( newHeight && parentWidth ) {
 					// set outer container size
 					t.container
 						.width(parentWidth)


### PR DESCRIPTION
Hi,

Noticed that in IE8 on window resizing expressions like

```
t.container.parent().closest(':visible').width()
```

might return `null` value that triggers errors. To fix it I added `not null` check additionally to `!= 0`.
