### PR TITLE
Allow click/touch event bubbling on time rail

### DIFF
--- a/src/js/mep-feature-progress.js
+++ b/src/js/mep-feature-progress.js
@@ -84,7 +84,6 @@
 							timefloat.hide();
 							t.globalUnbind('.dur');
 						});
-						return false;
 					}
 				})
 				.bind('mouseenter', function(e) {


### PR DESCRIPTION
Remove return false from time rail click/touch event to allow event bubbling
