### PR TITLE
Update mep-player.js

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -818,7 +818,7 @@
 					newHeight = t.isVideo || !t.options.autosizeProgress ? parseInt(parentWidth * nativeHeight/nativeWidth, 10) : nativeHeight;
 
 				// When we use percent, the newHeight can't be calculated so we get the container height
-				if(isNaN(newHeight) || ( parentHeight != 0 && newHeight > parentHeight )) {
+				if (isNaN(newHeight)) {
 					newHeight = parentHeight;
 				}
 


### PR DESCRIPTION
This is blowing up responsive design and players that are loaded dynamically. Because the parent container may be empty on load, race conditions exist that will override the height to the initial height of the parent, which may be something like 30px when the video has properly passed a height of something like 258px
