### PR TITLE
Fix a missing quote mark in Javascript + various other fixes -  accessibility slider control [Pull #1292]

### DIFF
--- a/src/css/mediaelementplayer.css
+++ b/src/css/mediaelementplayer.css
@@ -1,6 +1,7 @@
 .mejs-offscreen{
- 	position: absolute !important;
-	left: -10000px;
+/* Accessibility: hide screen reader texts (and prefer "top" for RTL languages). */
+	position: absolute !important;
+	top: -10000px;
 	overflow: hidden;
 	width: 1px;
 	height: 1px;

--- a/src/js/mep-feature-progress.js
+++ b/src/js/mep-feature-progress.js
@@ -1,11 +1,17 @@
 (function($) {
+
+	$.extend(mejs.MepDefaults, {
+		progessHelpText: mejs.i18n.t(
+		'Use Left/Right Arrow keys to advance one second, Up/Down arrows to advance ten seconds.')
+	});
+
 	// progress/loaded bar
 	$.extend(MediaElementPlayer.prototype, {
 		buildprogress: function(player, controls, layers, media) {
-			var progessOffScreenText = mejs.i18n.t('Use Left/Right Arrow keys to advance one second, Up/Down arrows to advance ten seconds.');
+
 			$('<div class="mejs-time-rail">' +
 				'<a href="javascript:void(0);" class="mejs-time-total mejs-time-slider">' +
-				'<span class="mejs-offscreen">' + progessOffScreenText + '</span>' +
+				'<span class="mejs-offscreen">' + this.options.progessHelpText + '</span>' +
 				'<span class="mejs-time-buffering"></span>' +
 				'<span class="mejs-time-loaded"></span>' +
 				'<span class="mejs-time-current"></span>' +
@@ -73,7 +79,7 @@
 				lastKeyPressTime = 0,
 				startedPaused = false,
 				autoRewindInitial = player.options.autoRewind;
-            //Ally for slider
+            // Accessibility for slider
             var updateSlider = function (e) {
 
 				var seconds = media.currentTime,
@@ -211,6 +217,7 @@
 			media.addEventListener('timeupdate', function(e) {
 				player.setProgressRail(e);
 				player.setCurrentRail(e);
+				updateSlider(e);
 			}, false);
 			
 			

--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -282,7 +282,8 @@
 
 				// remove native controls
 				t.$media.removeAttr('controls');
-				var videoPlayerTitle = mejs.i18n.t('Video Player');
+				var videoPlayerTitle = t.isVideo ?
+					mejs.i18n.t('Video Player') : mejs.i18n.t('Audio Player');
 				// build container
 				t.container =
 					$('<span class="mejs-offscreen">' + videoPlayerTitle + '</span>'+


### PR DESCRIPTION
Hi @johndyer and @rylan,

Rylan - thanks for your work on accessibility fixes - particularly on making hidden control bars work with screen readers. I got a colleague to [test our two progress bar enhancements](https://docs.google.com/document/d/1d1QKaKfOR6xDWw4UQIH7AN6GuxE8cpIUvYNoNTmAcKM/edit). As you discovered, your fixes came out better (though my colleague didn't test with NVDA or experience the specific problem that you found).

John and Rylan - I've fixed a missing quote mark in the commits for pull #1292, and some other improvements. I meant to get these to Rylan earlier, so that he could review - time has slipped by...

I hope this pull request helps. Best wishes,

Nick

---

https://github.com/IET-OU/mediaelement/commit/9359d22963f9b324d8e17f0fe47fb5462223b4f0
- Improve CSS style for ".mejs-offscreen" - prefer "top" for RTL languages.
- Make the text "Use Left/Right Arrow keys..." an option - so customized players can modify where and how they present this help text;
- Clarify JS comments - "Accessibility for slider" in place of "Ally for slider";
- Ensure "updateSlider()" Javascript function is called - to add WAI-ARIA attributes - role, aria-now, aria-min ...;
- src/js/mep-player.js:282 - ensure "videoPlayerTitle" applies to audio players as well as video players;
