### PR TITLE
Strict checks skip check for `undefined`

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -973,7 +973,7 @@
 			}
 
 			// second, try the real poster
-			if (posterUrl !== '' && posterUrl !== null) {
+			if ( posterUrl ) {
 				t.setPoster(posterUrl);
 			} else {
 				poster.hide();


### PR DESCRIPTION
This broke here:
https://github.com/johndyer/mediaelement/commit/9304e51fc52561acbf44341671796e919b5cbda3#diff-c828f76ddf61bb6b8160755ebf3de782R970

Ultimately, you want to not set the poster if the value of `posterUrl` is falsely. Previously, `undefined` didn't make it through because `undefined == null` equals `true` but `undefined === null` equals `false`. In the 2nd case, `posterUrl` is only checked for empty string and `null`, but the function call is derived from, `player.$media.attr('poster')`, returns `undefined`.

The side effect here is that setting `poster="undefined"` will cause an HTTP request in the background to the current `location.href + undefined`.
