### PR TITLE
Add configurable initVars for JavaScript init and event callback functions

### DIFF
--- a/src/flash/FlashMediaElement.as
+++ b/src/flash/FlashMediaElement.as
@@ -27,6 +27,8 @@ package
 	public class FlashMediaElement extends MovieClip {
 
 		private var _mediaUrl:String;
+		private var _jsInitFunction:String;
+		private var _jsCallbackFunction:String;
 		private var _autoplay:Boolean;
 		private var _preload:String;
 		private var _debug:Boolean;
@@ -141,6 +143,8 @@ package
 			}
 
 			_mediaUrl = (params['file'] != undefined) ? String(params['file']) : "";
+			_jsInitFunction = (params['jsinitfunction'] != undefined) ? String(params['jsinitfunction']) : "";
+			_jsCallbackFunction = (params['jscallbackfunction'] != undefined) ? String(params['jscallbackfunction']) : "";
 			_autoplay = (params['autoplay'] != undefined) ? (String(params['autoplay']) == "true") : false;
 			_debug = (params['debug'] != undefined) ? (String(params['debug']) == "true") : false;
 			_isVideo = (params['isvideo'] != undefined) ? ((String(params['isvideo']) == "false") ? false : true  ) : true;
@@ -375,7 +379,7 @@ package
 						ExternalInterface.addCallback("hideFullscreenButton", hideFullscreenButton);
 
 						// fire init method
-						ExternalInterface.call("mejs.MediaPluginBridge.initPlugin", ExternalInterface.objectID);
+						ExternalInterface.call(_jsCallbackFunction, ExternalInterface.objectID);
 					}
 
 					_output.appendText("Success...\n");
@@ -1040,7 +1044,7 @@ package
 
 				// use set timeout for performance reasons
 				//if (!_alwaysShowControls) {
-					ExternalInterface.call("setTimeout", "mejs.MediaPluginBridge.fireEvent('" + ExternalInterface.objectID + "','" + eventName + "'," + eventValues + ")",0);
+					ExternalInterface.call("setTimeout", _jsCallbackFunction + "('" + ExternalInterface.objectID + "','" + eventName + "'," + eventValues + ")",0);
 				//}
 			}
 		}

--- a/src/js/me-shim.js
+++ b/src/js/me-shim.js
@@ -500,6 +500,8 @@ mejs.HtmlMediaElementShim = {
 		// flash/silverlight vars
 		initVars = [
 			'id=' + pluginid,
+			'jsinitfunction=' + "mejs.MediaPluginBridge.initPlugin",
+			'jscallbackfunction=' + "mejs.MediaPluginBridge.fireEvent",
 			'isvideo=' + ((playback.isVideo) ? "true" : "false"),
 			'autoplay=' + ((autoplay) ? "true" : "false"),
 			'preload=' + preload,
@@ -508,7 +510,7 @@ mejs.HtmlMediaElementShim = {
 			'timerrate=' + options.timerRate,
 			'flashstreamer=' + options.flashStreamer,
 			'height=' + height,
-      'pseudostreamstart=' + options.pseudoStreamingStartQueryParam];
+			'pseudostreamstart=' + options.pseudoStreamingStartQueryParam];
 
 		if (playback.url !== null) {
 			if (playback.method == 'flash') {

--- a/src/silverlight/MainPage.xaml.cs
+++ b/src/silverlight/MainPage.xaml.cs
@@ -26,6 +26,8 @@ namespace SilverlightMediaElement
 
 		// variables
 		string _mediaUrl;
+        string _jsInitFunction;
+        string _jsCallbackFunction;
 		string _preload;
 		string _htmlid;
 		bool _autoplay = false;
@@ -76,6 +78,10 @@ namespace SilverlightMediaElement
 				_htmlid = initParams["id"];			
 			if (initParams.ContainsKey("file"))
 				_mediaUrl = initParams["file"];
+            if (initParams.ContainsKey("jsinitfunction"))
+                _jsInitFunction = initParams["jsinitfunction"];
+            if (initParams.ContainsKey("jscallbackfunction"))
+                _jsCallbackFunction = initParams["jscallbackfunction"];
 			if (initParams.ContainsKey("autoplay") && initParams["autoplay"] == "true")
 				_autoplay = true;
 			if (initParams.ContainsKey("debug") && initParams["debug"] == "true")
@@ -142,7 +148,7 @@ namespace SilverlightMediaElement
 			//HtmlPage.Window.Invoke("html5_MediaPluginBridge_initPlugin", new object[] {_htmlid});
 			try
 			{
-				HtmlPage.Window.Eval("mejs.MediaPluginBridge.initPlugin('" + _htmlid + "');");
+                HtmlPage.Window.Eval(_jsInitFunction + "('" + _htmlid + "');");
 			}
 			catch { }
 		}
@@ -320,7 +326,7 @@ namespace SilverlightMediaElement
 			try {
 				CultureInfo invCulture = CultureInfo.InvariantCulture;
 
-				HtmlPage.Window.Invoke("setTimeout", "mejs.MediaPluginBridge.fireEvent('" + _htmlid + "','" + name + "'," +
+				HtmlPage.Window.Invoke("setTimeout", _jsCallbackFunction + "('" + _htmlid + "','" + name + "'," +
 				@"{" +
 						@"""name"": """ + name + @"""" +
 						@", ""currentTime"":" + (media.Position.TotalSeconds).ToString(invCulture) + @"" +


### PR DESCRIPTION
Two new initVars for Flash and Silverlight fallbacks:
- `jsinitfunction`
- `jscallbackfunction`

This will make them more flexible and easier to use with other video libraries. Same approach is used in Adobe Strobe Media Playback player where's the `javascriptCallbackFunction` flashvar present.
