### PR TITLE
Fix startvolume parsing in Silverlight fallback

### DIFF
--- a/src/silverlight/MainPage.xaml.cs
+++ b/src/silverlight/MainPage.xaml.cs
@@ -96,7 +96,7 @@ namespace SilverlightMediaElement
 			if (initParams.ContainsKey("timerate"))
 				Int32.TryParse(initParams["timerrate"], out _timerRate);
 			if (initParams.ContainsKey("startvolume"))
-				Double.TryParse(initParams["startvolume"], out _volume);
+				Double.TryParse(initParams["startvolume"], NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out _volume);
 
 			if (_timerRate == 0)
 				_timerRate = 250;


### PR DESCRIPTION
startvolume initvar was improperly parsed using system dependent decimal separator. So if the system setting was to use comma as a decimal separator then startvolume set to e.g. "0.6" (with dot as a separator) was parsed to 0 not to double 0.6 as it should be. As the result player was always muted at start when the volume was set to value between 0-1.

Related to #1323
