### PR TITLE
Remove loading overlay only if it exists instead of failing

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -906,8 +906,11 @@ class MediaElementPlayer {
 						// Fixing an Android stock browser bug, where "seeked" isn't fired correctly after
 						// ending the video and jumping to the beginning
 						setTimeout(() => {
-							t.container.querySelector(`.${t.options.classPrefix}overlay-loading`)
-								.parentNode.style.display = 'none';
+							const loadingElement = t.container
+								.querySelector(`.${t.options.classPrefix}overlay-loading`);
+							if (loadingElement && loadingElement.parentNode) {
+								loadingElement.parentNode.style.display = 'none';
+							}
 						}, 20);
 					} catch (exp) {
 						console.log(exp);
@@ -1906,7 +1909,7 @@ class MediaElementPlayer {
 			node.style.display = '';
 			t.container.parentNode.insertBefore(node, t.container);
 			t.node.remove();
-			
+
 			// Add children
 			if (t.mediaFiles) {
 				for (let i = 0, total = t.mediaFiles.length; i < total; i++) {


### PR DESCRIPTION
Current code was trying to access the parent of an object that doesn't necessarily exist. I'm not well aware of how this library works, however, trying to build a custom player, that doesn't have a loading overlay I ran into issues. 