### PR TITLE
Enforce https

### DIFF
--- a/src/js/renderers/dailymotion.js
+++ b/src/js/renderers/dailymotion.js
@@ -44,7 +44,7 @@ const DailyMotionApi = {
 		if (!DailyMotionApi.isSDKStarted) {
 			const e = document.createElement('script');
 			e.async = true;
-			e.src = '//api.dmcdn.net/all.js';
+			e.src = 'https://api.dmcdn.net/all.js';
 			const s = document.getElementsByTagName('script')[0];
 			s.parentNode.insertBefore(e, s);
 			DailyMotionApi.isSDKStarted = true;

--- a/src/js/renderers/dash.js
+++ b/src/js/renderers/dash.js
@@ -54,7 +54,7 @@ const NativeDash = {
 		} else if (!NativeDash.isScriptLoaded) {
 
 			settings.options.path = typeof settings.options.path === 'string' ?
-				settings.options.path : '//cdn.dashjs.org/latest/dash.mediaplayer.min.js';
+				settings.options.path : 'https://cdn.dashjs.org/latest/dash.mediaplayer.min.js';
 
 			const
 				script = document.createElement('script'),

--- a/src/js/renderers/dash.js
+++ b/src/js/renderers/dash.js
@@ -115,7 +115,7 @@ const DashNativeRenderer = {
 		prefix: 'native_dash',
 		dash: {
 			// Special config: used to set the local path/URL of dash.js player library
-			path: '//cdn.dashjs.org/latest/dash.mediaplayer.min.js',
+			path: 'https://cdn.dashjs.org/latest/dash.mediaplayer.min.js',
 			debug: false
 		}
 	},

--- a/src/js/renderers/facebook.js
+++ b/src/js/renderers/facebook.js
@@ -375,7 +375,7 @@ const FacebookRenderer = {
 				}
 				const js = d.createElement(s);
 				js.id = id;
-				js.src = '//connect.facebook.net/en_US/sdk.js';
+				js.src = 'https://connect.facebook.net/en_US/sdk.js';
 				fjs.parentNode.insertBefore(js, fjs);
 			})(document, 'script', 'facebook-jssdk'));
 		}

--- a/src/js/renderers/flv.js
+++ b/src/js/renderers/flv.js
@@ -58,7 +58,7 @@ const NativeFlv = {
 		} else if (!NativeFlv.isMediaStarted) {
 
 			settings.options.path = typeof settings.options.path === 'string' ?
-				settings.options.path : '//cdnjs.cloudflare.com/ajax/libs/flv.js/1.2.0/flv.min.js';
+				settings.options.path : 'https://cdnjs.cloudflare.com/ajax/libs/flv.js/1.2.0/flv.min.js';
 
 			const
 				script = document.createElement('script'),

--- a/src/js/renderers/flv.js
+++ b/src/js/renderers/flv.js
@@ -116,7 +116,7 @@ const FlvNativeRenderer = {
 		prefix: 'native_flv',
 		flv: {
 			// Special config: used to set the local path/URL of flv.js library
-			path: '//cdnjs.cloudflare.com/ajax/libs/flv.js/1.2.0/flv.min.js',
+			path: 'https://cdnjs.cloudflare.com/ajax/libs/flv.js/1.2.0/flv.min.js',
 			// To modify more elements from FLV player,
 			// see https://github.com/Bilibili/flv.js/blob/master/docs/api.md#config
 			cors: true

--- a/src/js/renderers/hls.js
+++ b/src/js/renderers/hls.js
@@ -118,7 +118,7 @@ const HlsNativeRenderer = {
 		prefix: 'native_hls',
 		hls: {
 			// Special config: used to set the local path/URL of hls.js library
-			path: '//cdn.jsdelivr.net/hls.js/latest/hls.min.js',
+			path: 'https://cdn.jsdelivr.net/hls.js/latest/hls.min.js',
 			// To modify more elements from hls.js,
 			// see https://github.com/dailymotion/hls.js/blob/master/API.md#user-content-fine-tuning
 			autoStartLoad: false,

--- a/src/js/renderers/hls.js
+++ b/src/js/renderers/hls.js
@@ -58,7 +58,7 @@ const NativeHls = {
 		} else if (!NativeHls.isMediaStarted) {
 
 			settings.options.path = typeof settings.options.path === 'string' ?
-				settings.options.path : '//cdn.jsdelivr.net/hls.js/latest/hls.min.js';
+				settings.options.path : 'https://cdn.jsdelivr.net/hls.js/latest/hls.min.js';
 
 			const
 				script = document.createElement('script'),

--- a/src/js/renderers/soundcloud.js
+++ b/src/js/renderers/soundcloud.js
@@ -49,7 +49,7 @@ const SoundCloudApi = {
 
 			let done = false;
 
-			script.src = '//w.soundcloud.com/player/api.js';
+			script.src = 'https://w.soundcloud.com/player/api.js';
 
 			// Attach handlers for all browsers
 			// Is onload enough now? do IE9 support it?

--- a/src/js/renderers/twitch.js
+++ b/src/js/renderers/twitch.js
@@ -52,7 +52,7 @@ const twitchApi = {
 
 			let done = false;
 
-			script.src = '//player.twitch.tv/js/embed/v1.js';
+			script.src = 'https://player.twitch.tv/js/embed/v1.js';
 
 			// Attach handlers for all browsers
 			script.onload = script.onreadystatechange = function () {

--- a/src/js/renderers/vimeo.js
+++ b/src/js/renderers/vimeo.js
@@ -56,7 +56,7 @@ const vimeoApi = {
 
 			let done = false;
 
-			script.src = '//player.vimeo.com/api/player.js';
+			script.src = 'https://player.vimeo.com/api/player.js';
 
 			// Attach handlers for all browsers
 			script.onload = script.onreadystatechange = function() {

--- a/src/js/renderers/youtube.js
+++ b/src/js/renderers/youtube.js
@@ -54,7 +54,7 @@ const YouTubeApi = {
 	loadIframeApi: () => {
 		if (!YouTubeApi.isIframeStarted) {
 			const tag = document.createElement('script');
-			tag.src = '//www.youtube.com/player_api';
+			tag.src = 'https://www.youtube.com/player_api';
 			const firstScriptTag = document.getElementsByTagName('script')[0];
 			firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
 			YouTubeApi.isIframeStarted = true;


### PR DESCRIPTION
I'm using the media element at the `file://` protocol and hls fails to load since it also uses `file://`
Judging by how google and all other browser now wants too push everything to be secure (disabling js api's like geolocation etc) i think it would be best to use https wherever possible to strive towards a more secure environment

This also makes it a little bit safer agains MITM attacks, even if the main site is using http