### PR TITLE
Fix usage for iOS with native controls

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -712,7 +712,7 @@ class MediaElementPlayer {
 			t.enableControls();
 		}
 
-		if (t.container.querySelector(`.${t.options.classPrefix}overlay-play`)) {
+		if (t.container && t.container.querySelector(`.${t.options.classPrefix}overlay-play`)) {
 			t.container.querySelector(`.${t.options.classPrefix}overlay-play`).style.display = '';
 		}
 


### PR DESCRIPTION
If iPhoneUseNativeControls or iPadUseNativeControls is set to true, on
the respective device t.container won't be set. If t.container is
undefined there is no reason to change its "display" styling, so the if
will just be skipped in that case.