### PR TITLE
Fix detection of Fluid Mode

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1109,7 +1109,7 @@ class MediaElementPlayer {
 		const t = this;
 
 		// detect 100% mode - use currentStyle for IE since css() doesn't return percentages
-		return (~t.height.toString().indexOf('%') || (t.node && t.node.style.maxWidth && t.node.style.maxWidth !== 'none' &&
+		return (t.height.toString().indexOf('%') !== -1 || (t.node && t.node.style.maxWidth && t.node.style.maxWidth !== 'none' &&
 			t.node.style.maxWidth !== t.width) || (t.node && t.node.currentStyle && t.node.currentStyle.maxWidth === '100%'));
 	}
 


### PR DESCRIPTION
In Javascript the || operator does not necessarily return true or false,
but it returns the first value (if it is truthy) or the second value (if
the first value is falsey). This made this method return numbers instead
of booleans while the return value is compared to booleans with the
strict equal (===) operator which then gave wrong results.