### PR TITLE
Use methods rather than direct media property access

### DIFF
--- a/src/js/features/time.js
+++ b/src/js/features/time.js
@@ -103,7 +103,7 @@ Object.assign(MediaElementPlayer.prototype, {
 	updateCurrent ()  {
 		const t = this;
 
-		let currentTime = t.media.currentTime;
+		let currentTime = t.getCurrentTime();
 
 		if (isNaN(currentTime)) {
 			currentTime = 0;
@@ -121,7 +121,7 @@ Object.assign(MediaElementPlayer.prototype, {
 	updateDuration ()  {
 		const t = this;
 
-		let duration = t.media.duration;
+		let duration = t.getDuration();
 
 		if (isNaN(duration) || duration === Infinity || duration < 0) {
 			t.media.duration = t.options.duration = duration = 0;

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1818,6 +1818,10 @@ class MediaElementPlayer {
 		return this.media.currentTime;
 	}
 
+	getDuration () {
+		return this.media.duration;
+	}
+
 	setVolume (volume) {
 		this.media.setVolume(volume);
 	}


### PR DESCRIPTION
The benefit of this is that MediaElementPlayer can be subclassed to do interesting things with duration and current time (I'm combining several sequential audio files and treating them like a single very large file) by just overriding the `getDuration`, `getCurrentTime` and `setCurrentTime` methods.

I can add getDuration to the documentation if people think that would be useful. 