### PR TITLE
destroy() -> remove()

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -244,7 +244,7 @@ export default class MediaElement extends Component {
     
     componentWillUnmount() {
         if (this.state.player) {
-            this.state.player.destroy();
+            this.state.player.remove();
         }
     }
 }


### PR DESCRIPTION
`destroy()` wasn't a function, but updating it to `remove()` worked

is that what was intended to be here?