### PR TITLE
Feature: CSS sorting

### DIFF
--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -5,6 +5,7 @@
 	* [Renderers](#renderers)
 	* [Translations](#translations)
 	* [A word on `ES6` for Renderers](#es6)
+	* [CSS](#css)
 * [Node.js](#nodejs)
 * [Flex SDK](#flex)
 * [Building with Grunt](#building)
@@ -416,6 +417,11 @@ All the renderers are written using `Ecmascript 2015` specifications.
 See`src/js/renderers` directory, and check how the files were written to ensure compatibility.
 
 **Note**: the `for...of` loop could have been used, but in order to bundle them and reduce the size of the bundled files, it is **strongly recommended to avoid*** its use.
+
+<a id="css"></a>
+### CSS
+
+Sort CSS properties by alphabet to improve filesize when using gzip compression.
 
 <a id="nodejs"></a>
 ## Node.js

--- a/src/css/mediaelementplayer-legacy.css
+++ b/src/css/mediaelementplayer-legacy.css
@@ -3,20 +3,20 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 .mejs-offscreen {
     clip: rect(1px, 1px, 1px, 1px); /* IE8-IE11 - no support for clip-path */
     clip-path: polygon(0px 0px, 0px 0px, 0px 0px, 0px 0px);
-    position: absolute !important;
     height: 1px;
-    width: 1px;
     overflow: hidden;
+    position: absolute !important;
+    width: 1px;
 }
 
 .mejs-container {
-    position: relative;
     background: #000;
-    font-family: "Helvetica", Arial, serif;
-    text-align: left;
-    vertical-align: top;
-    text-indent: 0;
     box-sizing: border-box;
+    font-family: "Helvetica", Arial, serif;
+    position: relative;
+    text-align: left;
+    text-indent: 0;
+    vertical-align: top;
 }
 
 .mejs-container .mejs-video {
@@ -29,21 +29,21 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 
 /* Hide native play button from iOS to favor plugin button */
 .mejs-container video::-webkit-media-controls-start-playback-button {
-    display: none !important;
     -webkit-appearance: none;
+    display: none !important;
 }
 
 .mejs-fill-container,
 .mejs-fill-container .mejs-container {
-    width: 100%;
     height: 100%;
+    width: 100%;
 }
 
 .mejs-fill-container {
+    background: transparent;
+    margin: 0 auto;
     overflow: hidden;
     position: relative;
-    margin: 0 auto;
-    background: transparent;
 }
 
 .mejs-container:focus {
@@ -51,19 +51,19 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs-iframe-overlay {
+    height: 100%;
     position: absolute;
     width: 100%;
-    height: 100%;
 }
 
 .mejs-embed,
 .mejs-embed body {
-    width: 100%;
+    background: #000;
     height: 100%;
     margin: 0;
-    padding: 0;
-    background: #000;
     overflow: hidden;
+    padding: 0;
+    width: 100%;
 }
 
 .mejs-fullscreen {
@@ -71,19 +71,19 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs-container-fullscreen {
-    position: fixed;
-    left: 0;
-    top: 0;
-    right: 0;
     bottom: 0;
+    left: 0;
     overflow: hidden;
+    position: fixed;
+    right: 0;
+    top: 0;
     z-index: 1000;
 }
 
 .mejs-container-fullscreen .mejs-mediaelement,
 .mejs-container-fullscreen video {
-    width: 100% !important;
     height: 100% !important;
+    width: 100% !important;
 }
 
 .mejs-clear {
@@ -92,27 +92,27 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 
 /* Start: LAYERS */
 .mejs-background {
+    left: 0;
     position: absolute;
     top: 0;
-    left: 0;
 }
 
 .mejs-mediaelement {
+    height: 100%;
+    left: 0;
     position: absolute;
     top: 0;
-    left: 0;
     width: 100%;
-    height: 100%;
     z-index: 0;
 }
 
 .mejs-poster {
-    position: absolute;
-    top: 0;
-    left: 0;
-    background-size: contain;
     background-position: 50% 50%;
     background-repeat: no-repeat;
+    background-size: contain;
+    left: 0;
+    position: absolute;
+    top: 0;
     z-index: 1;
 }
 
@@ -126,9 +126,9 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs-overlay {
+    left: 0;
     position: absolute;
     top: 0;
-    left: 0;
     z-index: 1;
 }
 
@@ -141,15 +141,15 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs-overlay-button {
+    background-position: 0 -39px;
+    background: url("mejs-controls.svg") no-repeat;
+    height: 80px;
+    left: 50%;
+    margin: -40px 0 0 -40px;
+    overflow: hidden;
     position: absolute;
     top: 50%;
-    left: 50%;
     width: 80px;
-    height: 80px;
-    margin: -40px 0 0 -40px;
-    background: url("mejs-controls.svg") no-repeat;
-    background-position: 0 -39px;
-    overflow: hidden;
     z-index: 1;
 }
 
@@ -158,22 +158,22 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs-overlay-loading {
+    height: 80px;
+    left: 50%;
+    margin: -40px 0 0 -40px;
     position: absolute;
     top: 50%;
-    left: 50%;
     width: 80px;
-    height: 80px;
-    margin: -40px 0 0 -40px;
 }
 
 .mejs-overlay-loading-bg-img {
-    display: block;
-    width: 80px;
-    height: 80px;
-    background: transparent url("mejs-controls.svg") -160px -40px no-repeat;
     -webkit-animation: mejs-loading-spinner 1s linear infinite;
     -moz-animation: mejs-loading-spinner 1s linear infinite;
     animation: mejs-loading-spinner 1s linear infinite;
+    background: transparent url("mejs-controls.svg") -160px -40px no-repeat;
+    display: block;
+    height: 80px;
+    width: 80px;
     z-index: 1;
 }
 
@@ -200,13 +200,13 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 
 /* Start: CONTROL BAR */
 .mejs-controls {
-    position: absolute;
+    bottom: 0;
+    height: 40px;
+    left: 0;
     list-style-type: none;
     margin: 0;
     padding: 0 10px;
-    bottom: 0;
-    left: 0;
-    height: 40px;
+    position: absolute;
     width: 100%;
     z-index: 1;
 }
@@ -220,27 +220,27 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 .mejs-time,
 .mejs-time-rail {
     float: left;
+    font-size: 10px;
+    height: 40px;
+    line-height: 10px;
     margin: 0;
     width: 32px;
-    height: 40px;
-    font-size: 10px;
-    line-height: 10px;
 }
 
 .mejs-button > button {
+    background: transparent url("mejs-controls.svg");
+    border: 0;
     cursor: pointer;
     display: block;
     font-size: 0;
+    height: 20px;
     line-height: 0;
-    text-decoration: none;
     margin: 10px 6px;
+    overflow: hidden;
     padding: 0;
     position: absolute;
-    height: 20px;
+    text-decoration: none;
     width: 20px;
-    border: 0;
-    background: transparent url("mejs-controls.svg");
-    overflow: hidden;
 }
 
 /* :focus for accessibility */
@@ -261,16 +261,16 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 
 /* Start: Time (Current / Duration) */
 .mejs-time {
+    box-sizing: content-box;
     color: #fff;
     display: block;
-    height: 24px;
-    width: auto;
-    font-weight: bold;
     font-size: 11px;
-    padding: 16px 6px 0 6px;
+    font-weight: bold;
+    height: 24px;
     overflow: hidden;
+    padding: 16px 6px 0 6px;
     text-align: center;
-    box-sizing: content-box;
+    width: auto;
 }
 
 /* End: Time (Current / Duration) */
@@ -293,11 +293,11 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 /* Start: Progress Bar */
 .mejs-time-rail {
     direction: ltr;
-    width: 200px;
-    padding-top: 10px;
     height: 40px;
-    position: relative;
     margin: 0 10px;
+    padding-top: 10px;
+    position: relative;
+    width: 200px;
 }
 
 .mejs-time-total,
@@ -309,24 +309,24 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 .mejs-time-float-current,
 .mejs-time-float-corner,
 .mejs-time-marker {
+    border-radius: 2px;
     cursor: pointer;
     display: block;
-    position: absolute;
     height: 10px;
-    border-radius: 2px;
+    position: absolute;
 }
 
 .mejs-time-total {
-    margin: 5px 0 0 0;
     background: rgba(255, 255, 255, 0.3);
+    margin: 5px 0 0 0;
     width: 100%;
 }
 
 .mejs-time-buffering {
-    width: 100%;
+    animation: buffering-stripes 2s linear infinite;
     background: linear-gradient(-45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
     background-size: 15px 15px;
-    animation: buffering-stripes 2s linear infinite;
+    width: 100%;
 }
 
 @keyframes buffering-stripes {
@@ -356,13 +356,13 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs-time-current, .mejs-time-buffering, .mejs-time-loaded, .mejs-time-hovered {
-    width: 100%;
     left: 0;
     -ms-transform-origin: 0 0;
     transform-origin: 0 0;
     -ms-transform: scaleX(0);
     transform: scaleX(0);
     transition: .15s ease-in all;
+    width: 100%;
 }
 
 .mejs-time-hovered {
@@ -375,24 +375,24 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs-time-handle, .mejs-time-handle-content {
-    position: absolute;
-    cursor: pointer;
     border: 4px solid transparent;
-    z-index: 11;
+    cursor: pointer;
     left: 0;
+    position: absolute;
     -ms-transform: translateX(0px);
     transform: translateX(0px);
+    z-index: 11;
 }
 
 .mejs-time-handle-content {
-    left: -7px;
+    border-radius: 50%;
     border: 4px solid rgba(255, 255, 255, 0.9);
+    height: 10px;
+    left: -7px;
+    top: -4px;
     -ms-transform: scale(0);
     transform: scale(0);
-    top: -4px;
-    border-radius: 50%;
     width: 10px;
-    height: 10px;
 }
 
 .mejs-time-rail:hover .mejs-time-handle-content, .mejs-time-rail .mejs-time-handle-content:focus, .mejs-time-rail .mejs-time-handle-content:active {
@@ -401,42 +401,42 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs-time-float {
-    position: absolute;
-    display: none;
     background: #eee;
-    width: 36px;
-    height: 17px;
     border: solid 1px #333;
-    top: -26px;
-    margin-left: -18px;
-    text-align: center;
     color: #111;
+    display: none;
+    height: 17px;
+    margin-left: -18px;
+    position: absolute;
+    text-align: center;
+    top: -26px;
+    width: 36px;
 }
 
 .mejs-time-float-current {
-    margin: 2px;
-    width: 30px;
     display: block;
-    text-align: center;
     left: 0;
+    margin: 2px;
+    text-align: center;
+    width: 30px;
 }
 
 .mejs-time-float-corner {
-    position: absolute;
-    display: block;
-    width: 0;
-    height: 0;
-    line-height: 0;
-    border: solid 5px #eee;
     border-color: #eee transparent transparent transparent;
     border-radius: 0;
-    top: 15px;
+    border: solid 5px #eee;
+    display: block;
+    height: 0;
     left: 13px;
+    line-height: 0;
+    position: absolute;
+    top: 15px;
+    width: 0;
 }
 
 .mejs-long-video .mejs-time-float {
-    width: 64px;
     margin-left: -23px;
+    width: 64px;
 }
 
 .mejs-long-video .mejs-time-float-current {
@@ -449,10 +449,10 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 
 .mejs-broadcast {
     color: #fff;
-    position: absolute;
-    width: 100%;
     height: 10px;
+    position: absolute;
     top: 15px;
+    width: 100%;
 }
 
 /* End: Progress Bar */
@@ -482,16 +482,16 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs-volume-button > .mejs-volume-slider {
-    display: none;
-    height: 115px;
-    width: 25px;
     background: rgba(50, 50, 50, 0.7);
     border-radius: 0;
-    top: -115px;
+    display: none;
+    height: 115px;
     left: 5px;
-    z-index: 1;
-    position: absolute;
     margin: 0;
+    position: absolute;
+    top: -115px;
+    width: 25px;
+    z-index: 1;
 }
 
 .mejs-volume-button:hover {
@@ -499,70 +499,70 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs-volume-total {
-    position: absolute;
+    background: rgba(255, 255, 255, 0.5);
+    height: 100px;
     left: 11px;
+    margin: 0;
+    position: absolute;
     top: 8px;
     width: 2px;
-    height: 100px;
-    background: rgba(255, 255, 255, 0.5);
-    margin: 0;
 }
 
 .mejs-volume-current {
-    position: absolute;
-    left: 0;
-    bottom: 0;
-    width: 100%;
-    height: 100%;
     background: rgba(255, 255, 255, 0.9);
+    bottom: 0;
+    height: 100%;
+    left: 0;
     margin: 0;
+    position: absolute;
+    width: 100%;
 }
 
 .mejs-volume-handle {
-    position: absolute;
-    left: 0;
-    bottom: 100%;
-    width: 16px;
-    height: 6px;
-    margin: 0 0 -3px -7px;
     background: rgba(255, 255, 255, 0.9);
-    cursor: ns-resize;
     border-radius: 1px;
+    bottom: 100%;
+    cursor: ns-resize;
+    height: 6px;
+    left: 0;
+    margin: 0 0 -3px -7px;
+    position: absolute;
+    width: 16px;
 }
 
 .mejs-horizontal-volume-slider {
-    height: 36px;
-    width: 56px;
-    position: relative;
     display: block;
     float: left;
+    height: 36px;
+    position: relative;
     vertical-align: middle;
+    width: 56px;
 }
 
 .mejs-horizontal-volume-total {
-    position: absolute;
-    left: 0;
-    top: 16px;
-    width: 50px;
+    background: rgba(50, 50, 50, 0.8);
+    border-radius: 2px;
+    font-size: 1px;
     height: 8px;
+    left: 0;
     margin: 0;
     padding: 0;
-    font-size: 1px;
-    border-radius: 2px;
-    background: rgba(50, 50, 50, 0.8);
+    position: absolute;
+    top: 16px;
+    width: 50px;
 }
 
 .mejs-horizontal-volume-current {
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: 100%;
+    background: rgba(255, 255, 255, 0.8);
+    border-radius: 2px;
+    font-size: 1px;
     height: 100%;
+    left: 0;
     margin: 0;
     padding: 0;
-    font-size: 1px;
-    border-radius: 2px;
-    background: rgba(255, 255, 255, 0.8);
+    position: absolute;
+    top: 0;
+    width: 100%;
 }
 
 .mejs-horizontal-volume-handle {
@@ -585,16 +585,16 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs-captions-button > .mejs-captions-selector, .mejs-chapters-button > .mejs-chapters-selector {
-    visibility: hidden;
-    position: absolute;
-    bottom: 40px;
-    right: -51px;
-    width: 85px;
     background: rgba(50, 50, 50, 0.7);
-    border: solid 1px transparent;
-    padding: 0;
-    overflow: hidden;
     border-radius: 0;
+    border: solid 1px transparent;
+    bottom: 40px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    right: -51px;
+    visibility: hidden;
+    width: 85px;
 }
 
 .mejs-chapters-button > .mejs-chapters-selector {
@@ -606,21 +606,21 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs-captions-selector-list, .mejs-chapters-selector-list {
-    margin: 0;
-    padding: 0;
     display: block;
     list-style-type: none !important;
+    margin: 0;
     overflow: hidden;
+    padding: 0;
 }
 
 .mejs-captions-selector-list-item, .mejs-chapters-selector-list-item {
-    margin: 0 0 6px 0;
-    padding: 0 10px;
-    list-style-type: none !important;
-    display: block;
     color: #fff;
-    overflow: hidden;
     cursor: pointer;
+    display: block;
+    list-style-type: none !important;
+    margin: 0 0 6px 0;
+    overflow: hidden;
+    padding: 0 10px;
 }
 
 .mejs-captions-selector-list-item:hover, .mejs-chapters-selector-list-item:hover {
@@ -631,18 +631,18 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 .mejs-captions-selector-input, .mejs-chapters-selector-input {
     clear: both;
     float: left;
+    left: -1000px;
     margin: 3px 3px 0 5px;
     position: absolute;
-    left: -1000px;
 }
 
 .mejs-captions-selector-label, .mejs-chapters-selector-label {
-    width: 55px;
-    float: left;
-    padding: 4px 0 0 0;
-    line-height: 15px;
-    font-size: 10px;
     cursor: pointer;
+    float: left;
+    font-size: 10px;
+    line-height: 15px;
+    padding: 4px 0 0 0;
+    width: 55px;
 }
 
 .mejs-captions-selected, .mejs-chapters-selected {
@@ -655,13 +655,13 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs-captions-layer {
-    position: absolute;
     bottom: 0;
-    left: 0;
-    text-align: center;
-    line-height: 20px;
-    font-size: 16px;
     color: #fff;
+    font-size: 16px;
+    left: 0;
+    line-height: 20px;
+    position: absolute;
+    text-align: center;
 }
 
 .mejs-captions-layer a {
@@ -675,10 +675,10 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs-captions-position {
-    position: absolute;
-    width: 100%;
     bottom: 15px;
     left: 0;
+    position: absolute;
+    width: 100%;
 }
 
 .mejs-captions-position-hover {
@@ -686,10 +686,10 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs-captions-text, .mejs-captions-text * {
-    padding: 0;
     background: rgba(20, 20, 20, 0.5);
-    white-space: pre-wrap;
     box-shadow: 5px 0 0 rgba(20, 20, 20, 0.5), -5px 0 0 rgba(20, 20, 20, 0.5);
+    padding: 0;
+    white-space: pre-wrap;
 }
 
 .mejs-container.mejs-hide-cues video::-webkit-media-text-track-container {
@@ -708,8 +708,8 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .me_cannotplay span {
-    padding: 15px;
     display: block;
+    padding: 15px;
 }
 
 /* End: Error */

--- a/src/css/mediaelementplayer.css
+++ b/src/css/mediaelementplayer.css
@@ -3,20 +3,20 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 .mejs__offscreen {
     clip: rect(1px, 1px, 1px, 1px); /* IE8-IE11 - no support for clip-path */
     clip-path: polygon(0px 0px, 0px 0px, 0px 0px, 0px 0px);
-    position: absolute !important;
     height: 1px;
-    width: 1px;
     overflow: hidden;
+    position: absolute !important;
+    width: 1px;
 }
 
 .mejs__container {
-    position: relative;
     background: #000;
-    font-family: "Helvetica", Arial, serif;
-    text-align: left;
-    vertical-align: top;
-    text-indent: 0;
     box-sizing: border-box;
+    font-family: "Helvetica", Arial, serif;
+    position: relative;
+    text-align: left;
+    text-indent: 0;
+    vertical-align: top;
 }
 
 .mejs__container .mejs__video {
@@ -29,21 +29,21 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 
 /* Hide native play button from iOS to favor plugin button */
 .mejs__container video::-webkit-media-controls-start-playback-button {
-    display: none !important;
     -webkit-appearance: none;
+    display: none !important;
 }
 
 .mejs__fill-container,
 .mejs__fill-container .mejs__container {
-    width: 100%;
     height: 100%;
+    width: 100%;
 }
 
 .mejs__fill-container {
+    background: transparent;
+    margin: 0 auto;
     overflow: hidden;
     position: relative;
-    margin: 0 auto;
-    background: transparent;
 }
 
 .mejs__container:focus {
@@ -51,19 +51,19 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs__iframe-overlay {
+    height: 100%;
     position: absolute;
     width: 100%;
-    height: 100%;
 }
 
 .mejs__embed,
 .mejs__embed body {
-    width: 100%;
+    background: #000;
     height: 100%;
     margin: 0;
-    padding: 0;
-    background: #000;
     overflow: hidden;
+    padding: 0;
+    width: 100%;
 }
 
 .mejs__fullscreen {
@@ -71,19 +71,19 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs__container-fullscreen {
-    position: fixed;
-    left: 0;
-    top: 0;
-    right: 0;
     bottom: 0;
+    left: 0;
     overflow: hidden;
+    position: fixed;
+    right: 0;
+    top: 0;
     z-index: 1000;
 }
 
 .mejs__container-fullscreen .mejs__mediaelement,
 .mejs__container-fullscreen video {
-    width: 100% !important;
     height: 100% !important;
+    width: 100% !important;
 }
 
 .mejs__clear {
@@ -92,27 +92,27 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 
 /* Start: LAYERS */
 .mejs__background {
+    left: 0;
     position: absolute;
     top: 0;
-    left: 0;
 }
 
 .mejs__mediaelement {
+    height: 100%;
+    left: 0;
     position: absolute;
     top: 0;
-    left: 0;
     width: 100%;
-    height: 100%;
     z-index: 0;
 }
 
 .mejs__poster {
-    position: absolute;
-    top: 0;
-    left: 0;
-    background-size: contain;
     background-position: 50% 50%;
     background-repeat: no-repeat;
+    background-size: contain;
+    left: 0;
+    position: absolute;
+    top: 0;
     z-index: 1;
 }
 
@@ -126,9 +126,9 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs__overlay {
+    left: 0;
     position: absolute;
     top: 0;
-    left: 0;
     z-index: 1;
 }
 
@@ -141,15 +141,15 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs__overlay-button {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    width: 80px;
-    height: 80px;
-    margin: -40px 0 0 -40px;
     background: url("mejs-controls.svg") no-repeat;
     background-position: 0 -39px;
+    height: 80px;
+    left: 50%;
+    margin: -40px 0 0 -40px;
     overflow: hidden;
+    position: absolute;
+    top: 50%;
+    width: 80px;
     z-index: 1;
 }
 
@@ -158,22 +158,22 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs__overlay-loading {
+    height: 80px;
+    left: 50%;
+    margin: -40px 0 0 -40px;
     position: absolute;
     top: 50%;
-    left: 50%;
     width: 80px;
-    height: 80px;
-    margin: -40px 0 0 -40px;
 }
 
 .mejs__overlay-loading-bg-img {
-    display: block;
-    width: 80px;
-    height: 80px;
-    background: transparent url("mejs-controls.svg") -160px -40px no-repeat;
     -webkit-animation: mejs-loading-spinner 1s linear infinite;
     -moz-animation: mejs-loading-spinner 1s linear infinite;
     animation: mejs-loading-spinner 1s linear infinite;
+    background: transparent url("mejs-controls.svg") -160px -40px no-repeat;
+    display: block;
+    height: 80px;
+    width: 80px;
     z-index: 1;
 }
 
@@ -200,13 +200,13 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 
 /* Start: CONTROL BAR */
 .mejs__controls {
-    position: absolute;
+    bottom: 0;
+    height: 40px;
+    left: 0;
     list-style-type: none;
     margin: 0;
     padding: 0 10px;
-    bottom: 0;
-    left: 0;
-    height: 40px;
+    position: absolute;
     width: 100%;
     z-index: 1;
 }
@@ -220,27 +220,27 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 .mejs__time,
 .mejs__time-rail {
     float: left;
+    font-size: 10px;
+    height: 40px;
+    line-height: 10px;
     margin: 0;
     width: 32px;
-    height: 40px;
-    font-size: 10px;
-    line-height: 10px;
 }
 
 .mejs__button > button {
+    background: transparent url("mejs-controls.svg");
+    border: 0;
     cursor: pointer;
     display: block;
     font-size: 0;
+    height: 20px;
     line-height: 0;
-    text-decoration: none;
     margin: 10px 6px;
+    overflow: hidden;
     padding: 0;
     position: absolute;
-    height: 20px;
+    text-decoration: none;
     width: 20px;
-    border: 0;
-    background: transparent url("mejs-controls.svg");
-    overflow: hidden;
 }
 
 /* :focus for accessibility */
@@ -261,16 +261,16 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 
 /* Start: Time (Current / Duration) */
 .mejs__time {
+    box-sizing: content-box;
     color: #fff;
     display: block;
-    height: 24px;
-    width: auto;
-    font-weight: bold;
     font-size: 11px;
-    padding: 16px 6px 0 6px;
+    font-weight: bold;
+    height: 24px;
     overflow: hidden;
+    padding: 16px 6px 0 6px;
     text-align: center;
-    box-sizing: content-box;
+    width: auto;
 }
 
 /* End: Time (Current / Duration) */
@@ -293,11 +293,11 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 /* Start: Progress Bar */
 .mejs__time-rail {
     direction: ltr;
-    width: 200px;
-    padding-top: 10px;
     height: 40px;
-    position: relative;
     margin: 0 10px;
+    padding-top: 10px;
+    position: relative;
+    width: 200px;
 }
 
 .mejs__time-total,
@@ -309,24 +309,24 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 .mejs__time-float-current,
 .mejs__time-float-corner,
 .mejs__time-marker {
+    border-radius: 2px;
     cursor: pointer;
     display: block;
-    position: absolute;
     height: 10px;
-    border-radius: 2px;
+    position: absolute;
 }
 
 .mejs__time-total {
-    margin: 5px 0 0 0;
     background: rgba(255, 255, 255, 0.3);
+    margin: 5px 0 0 0;
     width: 100%;
 }
 
 .mejs__time-buffering {
-    width: 100%;
+    animation: buffering-stripes 2s linear infinite;
     background: linear-gradient(-45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
     background-size: 15px 15px;
-    animation: buffering-stripes 2s linear infinite;
+    width: 100%;
 }
 
 @keyframes buffering-stripes {
@@ -356,13 +356,13 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs__time-current, .mejs__time-buffering, .mejs__time-loaded, .mejs__time-hovered {
-    width: 100%;
     left: 0;
     -ms-transform-origin: 0 0;
     transform-origin: 0 0;
     -ms-transform: scaleX(0);
     transform: scaleX(0);
     transition: .15s ease-in all;
+    width: 100%;
 }
 
 .mejs__time-hovered {
@@ -375,24 +375,24 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs__time-handle, .mejs__time-handle-content {
-    position: absolute;
-    cursor: pointer;
     border: 4px solid transparent;
-    z-index: 11;
+    cursor: pointer;
     left: 0;
+    position: absolute;
     -ms-transform: translateX(0px);
     transform: translateX(0px);
+    z-index: 11;
 }
 
 .mejs__time-handle-content {
-    left: -7px;
+    border-radius: 50%;
     border: 4px solid rgba(255, 255, 255, 0.9);
+    height: 10px;
+    left: -7px;
+    top: -4px;
     -ms-transform: scale(0);
     transform: scale(0);
-    top: -4px;
-    border-radius: 50%;
     width: 10px;
-    height: 10px;
 }
 
 .mejs__time-rail:hover .mejs__time-handle-content, .mejs__time-rail .mejs__time-handle-content:focus, .mejs__time-rail .mejs__time-handle-content:active {
@@ -401,42 +401,42 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs__time-float {
-    position: absolute;
-    display: none;
     background: #eee;
-    width: 36px;
-    height: 17px;
     border: solid 1px #333;
-    top: -26px;
-    margin-left: -18px;
-    text-align: center;
     color: #111;
+    display: none;
+    height: 17px;
+    margin-left: -18px;
+    position: absolute;
+    text-align: center;
+    top: -26px;
+    width: 36px;
 }
 
 .mejs__time-float-current {
-    margin: 2px;
-    width: 30px;
     display: block;
-    text-align: center;
     left: 0;
+    margin: 2px;
+    text-align: center;
+    width: 30px;
 }
 
 .mejs__time-float-corner {
-    position: absolute;
-    display: block;
-    width: 0;
-    height: 0;
-    line-height: 0;
-    border: solid 5px #eee;
     border-color: #eee transparent transparent transparent;
     border-radius: 0;
-    top: 15px;
+    border: solid 5px #eee;
+    display: block;
+    height: 0;
     left: 13px;
+    line-height: 0;
+    position: absolute;
+    top: 15px;
+    width: 0;
 }
 
 .mejs__long-video .mejs__time-float {
-    width: 64px;
     margin-left: -23px;
+    width: 64px;
 }
 
 .mejs__long-video .mejs__time-float-current {
@@ -449,10 +449,10 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 
 .mejs__broadcast {
     color: #fff;
-    position: absolute;
-    width: 100%;
     height: 10px;
+    position: absolute;
     top: 15px;
+    width: 100%;
 }
 
 /* End: Progress Bar */
@@ -482,16 +482,16 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs__volume-button > .mejs__volume-slider {
-    display: none;
-    height: 115px;
-    width: 25px;
     background: rgba(50, 50, 50, 0.7);
     border-radius: 0;
-    top: -115px;
+    display: none;
+    height: 115px;
     left: 5px;
-    z-index: 1;
-    position: absolute;
     margin: 0;
+    position: absolute;
+    top: -115px;
+    width: 25px;
+    z-index: 1;
 }
 
 .mejs__volume-button:hover {
@@ -499,70 +499,70 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs__volume-total {
-    position: absolute;
+    background: rgba(255, 255, 255, 0.5);
+    height: 100px;
     left: 11px;
+    margin: 0;
+    position: absolute;
     top: 8px;
     width: 2px;
-    height: 100px;
-    background: rgba(255, 255, 255, 0.5);
-    margin: 0;
 }
 
 .mejs__volume-current {
-    position: absolute;
-    left: 0;
-    bottom: 0;
-    width: 100%;
-    height: 100%;
     background: rgba(255, 255, 255, 0.9);
+    bottom: 0;
+    height: 100%;
+    left: 0;
     margin: 0;
+    position: absolute;
+    width: 100%;
 }
 
 .mejs__volume-handle {
-    position: absolute;
-    left: 0;
-    bottom: 100%;
-    width: 16px;
-    height: 6px;
-    margin: 0 0 -3px -7px;
     background: rgba(255, 255, 255, 0.9);
-    cursor: ns-resize;
     border-radius: 1px;
+    bottom: 100%;
+    cursor: ns-resize;
+    height: 6px;
+    left: 0;
+    margin: 0 0 -3px -7px;
+    position: absolute;
+    width: 16px;
 }
 
 .mejs__horizontal-volume-slider {
-    height: 36px;
-    width: 56px;
-    position: relative;
     display: block;
     float: left;
+    height: 36px;
+    position: relative;
     vertical-align: middle;
+    width: 56px;
 }
 
 .mejs__horizontal-volume-total {
-    position: absolute;
-    left: 0;
-    top: 16px;
-    width: 50px;
+    background: rgba(50, 50, 50, 0.8);
+    border-radius: 2px;
+    font-size: 1px;
     height: 8px;
+    left: 0;
     margin: 0;
     padding: 0;
-    font-size: 1px;
-    border-radius: 2px;
-    background: rgba(50, 50, 50, 0.8);
+    position: absolute;
+    top: 16px;
+    width: 50px;
 }
 
 .mejs__horizontal-volume-current {
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: 100%;
+    background: rgba(255, 255, 255, 0.8);
+    border-radius: 2px;
+    font-size: 1px;
     height: 100%;
+    left: 0;
     margin: 0;
     padding: 0;
-    font-size: 1px;
-    border-radius: 2px;
-    background: rgba(255, 255, 255, 0.8);
+    position: absolute;
+    top: 0;
+    width: 100%;
 }
 
 .mejs__horizontal-volume-handle {
@@ -585,16 +585,16 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs__captions-button > .mejs__captions-selector, .mejs__chapters-button > .mejs__chapters-selector {
-    visibility: hidden;
-    position: absolute;
-    bottom: 40px;
-    right: -51px;
-    width: 85px;
     background: rgba(50, 50, 50, 0.7);
-    border: solid 1px transparent;
-    padding: 0;
-    overflow: hidden;
     border-radius: 0;
+    border: solid 1px transparent;
+    bottom: 40px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    right: -51px;
+    visibility: hidden;
+    width: 85px;
 }
 
 .mejs__chapters-button > .mejs__chapters-selector {
@@ -606,21 +606,21 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs__captions-selector-list, .mejs__chapters-selector-list {
-    margin: 0;
-    padding: 0;
     display: block;
     list-style-type: none !important;
+    margin: 0;
     overflow: hidden;
+    padding: 0;
 }
 
 .mejs__captions-selector-list-item, .mejs__chapters-selector-list-item {
-    margin: 0 0 6px 0;
-    padding: 0 10px;
-    list-style-type: none !important;
-    display: block;
     color: #fff;
-    overflow: hidden;
     cursor: pointer;
+    display: block;
+    list-style-type: none !important;
+    margin: 0 0 6px 0;
+    overflow: hidden;
+    padding: 0 10px;
 }
 
 .mejs__captions-selector-list-item:hover, .mejs__chapters-selector-list-item:hover {
@@ -631,18 +631,18 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 .mejs__captions-selector-input, .mejs__chapters-selector-input {
     clear: both;
     float: left;
+    left: -1000px;
     margin: 3px 3px 0 5px;
     position: absolute;
-    left: -1000px;
 }
 
 .mejs__captions-selector-label, .mejs__chapters-selector-label {
-    width: 55px;
-    float: left;
-    padding: 4px 0 0 0;
-    line-height: 15px;
-    font-size: 10px;
     cursor: pointer;
+    float: left;
+    font-size: 10px;
+    line-height: 15px;
+    padding: 4px 0 0 0;
+    width: 55px;
 }
 
 .mejs__captions-selected, .mejs__chapters-selected {
@@ -655,13 +655,13 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs__captions-layer {
-    position: absolute;
     bottom: 0;
-    left: 0;
-    text-align: center;
-    line-height: 20px;
-    font-size: 16px;
     color: #fff;
+    font-size: 16px;
+    left: 0;
+    line-height: 20px;
+    position: absolute;
+    text-align: center;
 }
 
 .mejs__captions-layer a {
@@ -675,10 +675,10 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs__captions-position {
-    position: absolute;
-    width: 100%;
     bottom: 15px;
     left: 0;
+    position: absolute;
+    width: 100%;
 }
 
 .mejs__captions-position-hover {
@@ -686,10 +686,10 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs__captions-text, .mejs__captions-text * {
-    padding: 0;
     background: rgba(20, 20, 20, 0.5);
-    white-space: pre-wrap;
     box-shadow: 5px 0 0 rgba(20, 20, 20, 0.5), -5px 0 0 rgba(20, 20, 20, 0.5);
+    padding: 0;
+    white-space: pre-wrap;
 }
 
 .mejs__container.mejs__hide-cues video::-webkit-media-text-track-container {
@@ -708,8 +708,8 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .me_cannotplay span {
-    padding: 15px;
     display: block;
+    padding: 15px;
 }
 
 /* End: Error */


### PR DESCRIPTION
I've sorted all CSS properties by alphabet to reduce filesize when using gzip compression.
Find more information about the topic [here](http://peteschuster.com/2014/12/reduce-file-size-css-sorting/).
I know it is not much but in a large application every byte counts. This will also improve maintainability in my opinion because new contributors will always know where to put new properties.
I've also left a short note in `guidelines.md`.
On long-term, I suggest implementing some kind of CSS linter. My weapon of choice is [Stylelint](https://stylelint.io/) which is very powerful and is very flexible in configuration.

Filename | Before | After | Saving | Before gzip | After gzip | Saving gzip
--- | --- | --- | --- | --- | --- | ---
mediaelementplayer-legacy.css | 13824 | 13824 | 0 | 3050 | 3033 | 17
mediaelementplayer-legacy.min.css | 10343 | 10343 | 0 | 2507 | 2502 | 5
mediaelementplayer.css | 13968 | 13968 | 0 | 3050 | 3037 | 13
mediaelementplayer.min.css | 10492 | 10492 | 0 | 2515 | 2507 | 8

Filesize in bytes