### PR TITLE
New Option to make player full window width

### DIFF
--- a/build/mediaelement-and-player.js
+++ b/build/mediaelement-and-player.js
@@ -3369,6 +3369,8 @@ var config = exports.config = {
 
 	customError: null,
 
+	fullWindowWidth: false,
+	
 	keyActions: [{
 		keys: [32, 179],
 		action: function action(player) {
@@ -4349,7 +4351,7 @@ var MediaElementPlayer = function () {
 			    parentHeight = parseFloat(parentStyles.height);
 
 			var newHeight = void 0,
-			    parentWidth = parseFloat(parentStyles.width);
+			    parentWidth = (t.options.fullWindowWidth) ? $(window).width() : parseFloat(parentStyles.width);
 
 			if (t.isVideo) {
 				if (t.height === '100%') {


### PR DESCRIPTION
I have a player set up to span whole window width. Although player does a good job of stretching it self when I stretch my window (fast enough, bit exaggerated!!), but it lags often and thus does not fill the width completely. This problem is also exhibits on mobile on orientation change. In fact `parseFloat(parentStyles.width)` is not always equals to the window width.

With my changes above, it solves that problem. 

Thank you