### PR TITLE
New Option to stretch player to full browser width

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1152,7 +1152,7 @@ class MediaElementPlayer {
 
 		let
 			newHeight,
-			parentWidth = (t.options.fullWindowWidth) ? window.offsetWidth : parseFloat(parentStyles.width);
+			parentWidth = (t.options.fullWindowWidth) ? $(window).width() : parseFloat(parentStyles.width);
 		;
 
 		if (t.isVideo) {

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -122,6 +122,9 @@ export const config = {
 	secondsDecimalLength: 0,
 	// If error happens, set up HTML message via string or function
 	customError: null,
+	// Make player stretch to full browser width, when used with Stretching mode responsive  
+	fullWindowWidth: false,
+	
 	// Array of keyboard actions such as play/pause
 	keyActions: [
 		{
@@ -1149,7 +1152,7 @@ class MediaElementPlayer {
 
 		let
 			newHeight,
-			parentWidth = parseFloat(parentStyles.width)
+			parentWidth = (t.options.fullWindowWidth) ? window.offsetWidth : parseFloat(parentStyles.width);
 		;
 
 		if (t.isVideo) {


### PR DESCRIPTION
I have a player set up to span whole browser width. Although player does a good job of stretching it self when I stretch my browser window (fast enough, bit exaggerated!!), but it lags often and thus does not fill the width completely. This problem is also exhibits on mobile on orientation change. In fact `parseFloat(parentStyles.width)` is not always equals to the window width.

PS: As discussed here https://github.com/mediaelement/mediaelement/pull/2355

Test url http://tinyurl.com/y8mnxgse
