### PR TITLE
Remember startVolume even if video is muted, so unmuting will set the original startVolume instead of zero

### DIFF
--- a/src/js/features/volume.js
+++ b/src/js/features/volume.js
@@ -432,7 +432,6 @@ Object.assign(MediaElementPlayer.prototype, {
 				if (!modified && !rendered) {
 					if (player.options.startVolume === 0 || media.originalNode.muted) {
 						media.setMuted(true);
-						player.options.startVolume = 0;
 					}
 					media.setVolume(player.options.startVolume);
 					t.setControlsSize();


### PR DESCRIPTION
Closes: #2457