### PR TITLE
Fix video player in iFrame expanding infinitely on iOS Safari

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -921,13 +921,16 @@ class MediaElementPlayer {
 			}, 0);
 
 			t.globalResizeCallback = () => {
-				// don't resize for fullscreen mode
-				if (!(t.isFullScreen || (HAS_TRUE_NATIVE_FULLSCREEN && document.webkitIsFullScreen))) {
-					t.setPlayerSize(t.width, t.height);
-				}
+				// don't resize inside an iframe
+				if (!t.isInIframe) {
+					// don't resize for fullscreen mode
+					if (!(t.isFullScreen || (HAS_TRUE_NATIVE_FULLSCREEN && document.webkitIsFullScreen))) {
+						t.setPlayerSize(t.width, t.height);
+					}
 
-				// always adjust controls
-				t.setControlsSize();
+					// always adjust controls
+					t.setControlsSize();
+				}
 			};
 
 


### PR DESCRIPTION
**Description**
Viewing an embedded player on mobile Safari results in a slow, constant expansion of the media player's size.

**Environment**
iPad 4 running latest mobile Safari on Browserstack

**Example**
![image](https://user-images.githubusercontent.com/1406618/34176615-8d1c3110-e4ce-11e7-83e4-54f07fa41c92.gif)

More details can be found here: https://github.com/avalonmediasystem/avalon/issues/2632
  