### PR TITLE
Fix getComputedStyle in firefox

### DIFF
--- a/src/js/utils/constants.js
+++ b/src/js/utils/constants.js
@@ -32,7 +32,7 @@ export const SUPPORT_POINTER_EVENTS = (() => {
 	element.style.pointerEvents = 'auto';
 	element.style.pointerEvents = 'x';
 	documentElement.appendChild(element);
-	let supports = getComputedStyle && getComputedStyle(element, '').pointerEvents === 'auto';
+	let supports = getComputedStyle && (getComputedStyle(element, '') || {}).pointerEvents === 'auto';
 	element.remove();
 	return !!supports;
 })();


### PR DESCRIPTION
According to https://bugzilla.mozilla.org/show_bug.cgi?id=548397 Firefox can return null when calling getComputedStyle on element in hidden iframe.