### PR TITLE
Vimeo embed iframe XML/XHTML well-formedness

### DIFF
--- a/src/js/renderers/facebook.js
+++ b/src/js/renderers/facebook.js
@@ -369,7 +369,7 @@ const FacebookRenderer = {
 		fbContainer.id = fb.id;
 		fbContainer.className = 'fb-video';
 		fbContainer.setAttribute('data-href', src);
-		fbContainer.setAttribute('data-allowfullscreen', true);
+		fbContainer.setAttribute('data-allowfullscreen', 'true');
 		fbContainer.setAttribute('data-controls', !!mediaElement.originalNode.controls);
 		mediaElement.originalNode.parentNode.insertBefore(fbContainer, mediaElement.originalNode);
 		mediaElement.originalNode.style.display = 'none';

--- a/src/js/renderers/vimeo.js
+++ b/src/js/renderers/vimeo.js
@@ -403,9 +403,9 @@ const vimeoIframeRenderer = {
 		vimeoContainer.setAttribute('height', height);
 		vimeoContainer.setAttribute('frameBorder', '0');
 		vimeoContainer.setAttribute('src', `${standardUrl}${queryArgs}`);
-		vimeoContainer.setAttribute('webkitallowfullscreen', '');
-		vimeoContainer.setAttribute('mozallowfullscreen', '');
-		vimeoContainer.setAttribute('allowfullscreen', '');
+		vimeoContainer.setAttribute('webkitallowfullscreen', 'true');
+		vimeoContainer.setAttribute('mozallowfullscreen', 'true');
+		vimeoContainer.setAttribute('allowfullscreen', 'true');
 
 		mediaElement.originalNode.parentNode.insertBefore(vimeoContainer, mediaElement.originalNode);
 		mediaElement.originalNode.style.display = 'none';


### PR DESCRIPTION
Make sure that XML/XHTML well-formedness doesn't get accidentally broken by (*)`allowfullscreen` of Vimeo embed `iframe`.