### PR TITLE
startLanguage and toggleCaptionsButtonWhenOnlyOne

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -133,7 +133,7 @@ useFakeFullscreen | boolean | `false` | Flag to bypass native capabilities on mo
 tracksAriaLive | boolean | `false` | By default, no WAI-ARIA live region - don't make a screen reader speak captions over an audio track.
 hideCaptionsButtonWhenEmpty | boolean | `true` | Option to remove the `[cc]` button when no `<track kind="subtitles">` are present
 toggleCaptionsButtonWhenOnlyOne | boolean | `false` | If true and we only have one track, change captions to toggle button
-startLanguage | string | _(empty)_ | Automatically turn on a `<track>` element
+startLanguage | string | _(empty)_ | Automatically turn on a `<track>` element. Note: Will not work when toggleCaptionsButtonWhenOnlyOne is set to `true`
 slidesSelector | string | _(empty)_ | Selector for slides; could be any valid Javascript selector (`#id`, `.class`, `img`, etc.)
 tracksText | string | `null` | Title for Closed Captioning button for WARIA purposes
 chaptersText  | string | `null` | Title for Chapters button for WARIA purposes


### PR DESCRIPTION
Cannot use startLanguage whenever toggleCaptionsButtonWhenOnlyOne is set to `true`.