### PR TITLE
Update mediaelement-and-player.js

### DIFF
--- a/build/mediaelement-and-player.js
+++ b/build/mediaelement-and-player.js
@@ -3088,6 +3088,7 @@ Object.assign(_player2.default.prototype, {
 			anchor.setAttribute('aria-label', _i18n2.default.t('mejs.volume-slider'));
 			anchor.setAttribute('aria-valuemin', 0);
 			anchor.setAttribute('aria-valuemax', 100);
+			anchor.setAttribute('aria-valuenow', 100);
 			anchor.setAttribute('role', 'slider');
 			anchor.innerHTML += '<span class="' + t.options.classPrefix + 'offscreen">' + volumeControlText + '</span>' + ('<div class="' + t.options.classPrefix + 'horizontal-volume-total">') + ('<div class="' + t.options.classPrefix + 'horizontal-volume-current"></div>') + ('<div class="' + t.options.classPrefix + 'horizontal-volume-handle"></div>') + '</div>';
 			mute.parentNode.insertBefore(anchor, mute.nextSibling);


### PR DESCRIPTION
Adding the aria-valuenow attribute as a default attribute to ensure validation of WCAG 4.1.1 and WCAG 4.1.2.

This is mission critical for me right now as my site https://a11yrules.com is being evaluated for inclusion on a W3C showcase for accessibility.

Perhaps not the best approach - you know your plugin - but should do the trick.