### PR TITLE
Added handling of the .play() promise errors to native_hls player

### DIFF
--- a/build/mediaelement-and-player.js
+++ b/build/mediaelement-and-player.js
@@ -863,7 +863,8 @@ var MediaElement = function MediaElement(idOrNode, options, sources) {
 	},
 	    triggerAction = function triggerAction(methodName, args) {
 		try {
-			if (methodName === 'play' && t.mediaElement.rendererName === 'native_dash') {
+		    if (methodName === 'play' && (t.mediaElement.rendererName === 'native_dash' || t.mediaElement.rendererName === 'native_hls')) {
+			        console.log('play promise called');
 				var response = t.mediaElement.renderer[methodName](args);
 				if (response && typeof response.then === 'function') {
 					response.catch(function () {

--- a/build/mediaelement-and-player.js
+++ b/build/mediaelement-and-player.js
@@ -864,7 +864,6 @@ var MediaElement = function MediaElement(idOrNode, options, sources) {
 	    triggerAction = function triggerAction(methodName, args) {
 		try {
 		    if (methodName === 'play' && (t.mediaElement.rendererName === 'native_dash' || t.mediaElement.rendererName === 'native_hls')) {
-			        console.log('play promise called');
 				var response = t.mediaElement.renderer[methodName](args);
 				if (response && typeof response.then === 'function') {
 					response.catch(function () {

--- a/src/js/core/mediaelement.js
+++ b/src/js/core/mediaelement.js
@@ -389,8 +389,10 @@ class MediaElement {
 			},
 			triggerAction = (methodName, args) => {
 				try {
-					// Sometimes, playing native DASH media might throw `DOMException: The play() request was interrupted`.
-					if (methodName === 'play' && t.mediaElement.rendererName === 'native_dash') {
+				        // Sometimes, playing native DASH media might throw `DOMException: The play() request was interrupted`.
+				        // Add this for native HLS playback as well
+				        if (methodName === 'play' &&
+					    (t.mediaElement.rendererName === 'native_dash' || t.mediaElement.rendererName === 'native_hls') {
 						const response = t.mediaElement.renderer[methodName](args);
 						if (response && typeof response.then === 'function') {
 							response.catch(() => {


### PR DESCRIPTION
I was still getting 'Uncaught (in promise) DOMException: The play() request was interrupted by a call to pause().' errors when playing HLS streams with the native_hls renderer.

I looked through the source and saw that this was being handled for the native_dash renderer in /src/js/core/mediaelement.js, so I included a simple change to add the handling for native_hls renderer as well.

This has removed those errors for me and playback seems to work fine.

Long-term, this will all likely be solved by the feature-request from issue #2414 which will allow the promise to be returned to the user for proper handling. But for now, this appears to eliminate these errors.

One issue is that I didn't build the final JS files (e.g. /build/mediaelement-and-player.js) so in my pull request those files don't reflect the code changes. I wasn't sure how you build those files, so I just made the change manually in my local copy :-)

If you merge this PR, you'll need to build the final files yourself, or if you can tell me how to do that, I'll be happy to do so and submit a new PR.

Anyway, please let me know if there are any problems with this PR. Thanks for all your work on an awesome piece of software! :-)
