### PR TITLE
Fix time slider swallowing the first 2%

### DIFF
--- a/src/js/features/progress.js
+++ b/src/js/features/progress.js
@@ -198,7 +198,7 @@ Object.assign(MediaElementPlayer.prototype, {
 
 					pos = x - offsetStyles.left;
 					percentage = (pos / width);
-					t.newTime = (percentage <= 0.02) ? 0 : percentage * t.getDuration();
+					t.newTime = percentage * t.getDuration();
 
 					// fake seek to where the mouse is
 					if (mouseIsDown && t.getCurrentTime() !== null && t.newTime.toFixed(4) !== t.getCurrentTime().toFixed(4)) {


### PR DESCRIPTION
Especially on longer videos, it's currently impossible to skip the first seconds of a video because the slider ignores the first 2%. Clicking anywhere withing those 2% will result in the video being restarted.