### PR TITLE
Fix #2123: do not modify any global window objects

### DIFF
--- a/src/js/player/library.js
+++ b/src/js/player/library.js
@@ -5,11 +5,11 @@ import mejs from '../core/mejs';
 import MediaElementPlayer from '../player';
 
 if (typeof jQuery !== 'undefined') {
-	mejs.$ = window.jQuery = window.$ = jQuery;
+	mejs.$ = jQuery;
 } else if (typeof Zepto !== 'undefined') {
-	mejs.$ = window.Zepto = window.$ = Zepto;
+	mejs.$ = Zepto;
 } else if (typeof ender !== 'undefined') {
-	mejs.$ = window.ender = window.$ = ender;
+	mejs.$ = ender;
 }
 
 // turn into plugin


### PR DESCRIPTION
No longer modify any objects under the global window scope to prevent side effect.