### PR TITLE
Bug before media loads and currentTime is not a number

### DIFF
--- a/src/js/features/progress.js
+++ b/src/js/features/progress.js
@@ -392,7 +392,7 @@ Object.assign(MediaElementPlayer.prototype, {
 						return;
 				}
 
-				seekTime = seekTime < 0 ? 0 : (seekTime >= duration ? duration : Math.floor(seekTime));
+				seekTime = seekTime < 0 || isNaN(seekTime) ? 0 : seekTime >= duration ? duration : Math.floor(seekTime);
 				lastKeyPressTime = new Date();
 				if (!startedPaused) {
 					player.pause();

--- a/src/js/features/progress.js
+++ b/src/js/features/progress.js
@@ -392,8 +392,8 @@ Object.assign(MediaElementPlayer.prototype, {
 						return;
 				}
 
-				seekTime = seekTime < 0 || isNaN(seekTime) ? 0 : seekTime >= duration ? duration : Math.floor(seekTime);
-				lastKeyPressTime = new Date();
+				seekTime = seekTime < 0 || isNaN(seekTime) ? 0 : (seekTime >= duration ? duration : Math.floor(seekTime);
+				lastKeyPressTime = new Date());
 				if (!startedPaused) {
 					player.pause();
 				}

--- a/src/js/features/progress.js
+++ b/src/js/features/progress.js
@@ -392,8 +392,8 @@ Object.assign(MediaElementPlayer.prototype, {
 						return;
 				}
 
-				seekTime = seekTime < 0 || isNaN(seekTime) ? 0 : (seekTime >= duration ? duration : Math.floor(seekTime);
-				lastKeyPressTime = new Date());
+				seekTime = seekTime < 0 || isNaN(seekTime) ? 0 : (seekTime >= duration ? duration : Math.floor(seekTime));
+				lastKeyPressTime = new Date();
 				if (!startedPaused) {
 					player.pause();
 				}

--- a/src/js/features/progress.js
+++ b/src/js/features/progress.js
@@ -281,7 +281,7 @@ Object.assign(MediaElementPlayer.prototype, {
 				if (media.paused) {
 					t.slider.setAttribute('aria-label', timeSliderText);
 					t.slider.setAttribute('aria-valuemin', 0);
-					t.slider.setAttribute('aria-valuemax', duration);
+					t.slider.setAttribute('aria-valuemax', isNaN(duration) ? 0 : duration);
 					t.slider.setAttribute('aria-valuenow', seconds);
 					t.slider.setAttribute('aria-valuetext', time);
 				} else {

--- a/src/js/renderers/dash.js
+++ b/src/js/renderers/dash.js
@@ -151,7 +151,7 @@ const DashNativeRenderer = {
 								}
 							}
 						} else {
-							node[propName] = value;
+							if (value > 0) node[propName] = value;
 						}
 					}
 				};

--- a/src/js/renderers/flv.js
+++ b/src/js/renderers/flv.js
@@ -142,7 +142,7 @@ const FlvNativeRenderer = {
 								flvPlayer.load();
 							}
 						} else {
-							node[propName] = value;
+							if (value > 0) node[propName] = value;
 						}
 					}
 				};

--- a/src/js/renderers/hls.js
+++ b/src/js/renderers/hls.js
@@ -139,7 +139,7 @@ const HlsNativeRenderer = {
 								hlsPlayer.attachMedia(node);
 							}
 						} else {
-							node[propName] = value;
+							if (value > 0) node[propName] = value;
 						}
 					}
 				};

--- a/src/js/renderers/html5.js
+++ b/src/js/renderers/html5.js
@@ -73,7 +73,7 @@ const HtmlMediaElement = {
 
 				node[`set${capName}`] = (value) => {
 					if (mejs.html5media.readOnlyProperties.indexOf(propName) === -1) {
-						node[propName] = value;
+						if (value > 0) node[propName] = value;
 					}
 				};
 			}
@@ -87,7 +87,7 @@ const HtmlMediaElement = {
 			events = mejs.html5media.events.concat(['click', 'mouseover', 'mouseout']).filter(e => e !== 'error'),
 			assignEvents = (eventName) => {
 				node.addEventListener(eventName, (e) => {
-					// Emmit an event only in case of the renderer is active at the moment
+					// Emit an event only in case the renderer is active at the moment
 					if (isActive) {
 						const event = createEvent(e.type, e.target);
 						mediaElement.dispatchEvent(event);


### PR DESCRIPTION
`seekTime = seekTime < 0 ? 0 : (seekTime >= duration ? duration : Math.floor(seekTime));`

Change To:

`seekTime = seekTime < 0 || isNaN(seekTime) ? 0 : (seekTime >= duration ? duration : Math.floor(seekTime));`

An error occurs when the user first clicks the time-slider and presses the Right or Left arrow key immediately after that to manually seek backward or forward, since the media has not yet loaded. The value for seek +-` currentTime` is not a number. `currentTime` is not a number.
