### PR TITLE
Fixes Safari critical error on video element children

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -376,7 +376,7 @@ class MediaElementPlayer {
 							tracks.push(childNode);
 							break;
 						default:
-							cloneNode.appendChild(childNode);
+							cloneNode.appendChild(childNode.cloneNode(true));
 							break;
 					}
 				}


### PR DESCRIPTION
#2667 If the video element has any other tags than track and source, javascript errors and fails to load player