### PR TITLE
Fix dash.js (@daveyx,#2659)

### DIFF
--- a/src/js/renderers/dash.js
+++ b/src/js/renderers/dash.js
@@ -171,10 +171,7 @@ const DashNativeRenderer = {
 				assignEvents = (eventName) => {
 					if (eventName === 'loadedmetadata') {
 						// Basic configuration
-						dashPlayer.getDebug().setLogToBrowserConsole(options.dash.debug);
 						dashPlayer.initialize();
-						dashPlayer.setScheduleWhilePaused(false);
-						dashPlayer.setFastSwitchEnabled(true);
 						dashPlayer.attachView(node);
 						dashPlayer.setAutoPlay(false);
 


### PR DESCRIPTION
Method Debug.setLogToBrowserConsole has been deprecated in dash.js since v2.7.0
(https://github.com/Dash-Industry-Forum/dash.js/issues/2749)
