### PR TITLE
Fix broken urls

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -378,7 +378,7 @@ Below are listed the renderers with their IDs and player instance to execute oth
 Renderer | ID | Reference | MIME Type(s)
 --- | -- | --- | ---
 Native video/audio | `html5` | --- | video/mp4, audio/mp4, video/webm, audio/mpeg, audio/mp3, audio/ogg, audio/oga, video/ogg
-HLS native | `native_hls` | [`hls.js` API](https://github.com/dailymotion/hls.js/blob/master/doc/API.md) | application/x-mpegURL, vnd.apple.mpegURL
+HLS native | `native_hls` | [`hls.js` API](https://github.com/dailymotion/hls.js/blob/master/docs/API.md) | application/x-mpegURL, vnd.apple.mpegURL
 M(PEG)-DASH native | `native_dash` | [`dash.js` Documentation](http://cdn.dashjs.org/latest/jsdoc/index.html) | application/dash+xml
 FLV native | `native_flv` | [`flv.js` API](https://github.com/Bilibili/flv.js/blob/master/docs/api.md) | video/flv
 SoundCloud | `soundcloud_iframe` | [SoundCloud Widget API](https://developers.soundcloud.com/docs/api/html5-widget) | video/soundcloud, video/x-soundcloud

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -386,7 +386,7 @@ Facebook | `facebook` | --- | video/facebook, video/x-facebook
 Vimeo | `vimeo_iframe` | [Vimeo Player API](https://github.com/vimeo/player.js) | video/vimeo, video/x-vimeo
 YouTube | `youtube_iframe` | [YouTube IFrame Player API](https://developers.google.com/youtube/iframe_api_reference) | video/youtube, video/x-youtube
 DailyMotion | `dailymotion_iframe` | [Dailymotion Player API](https://developer.dailymotion.com/player#player-api) | video/dailymotion, video/x-dailymotion
-Twitch | `twitch_iframe` | [Twitch Emded API](https://github.com/justintv/Twitch-API/blob/master/embed-video.md) | video/twitch, video/x-twitch
+Twitch | `twitch_iframe` | [Twitch Emded API](https://dev.twitch.tv/docs/embed/video-and-clips/) | video/twitch, video/x-twitch
 Video shim  | `flash_video` | --- | video/mp4, video/rtmp, audio/rtmp, rtmp/mp4, audio/mp4
 Audio shim | `flash_audio` | --- | audio/mp3
 OGG Audio shim  | `flash_audio_ogg` | --- | audio/ogg, audio/oga


### PR DESCRIPTION
1. hls.js API
2. Twitch Emded API
Twitch-API repo is deprecated and all documentation for the Twitch API has been moved to the Twitch Developer Website.