### PR TITLE
Handle captions files missing text at end of file.

### DIFF
--- a/src/js/features/tracks.js
+++ b/src/js/features/tracks.js
@@ -899,7 +899,7 @@ mejs.TrackFormatParser = {
 						text = `${text}\n${lines[i]}`;
 						i++;
 					}
-					text = text.trim().replace(/(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig, "<a href='$1' target='_blank'>$1</a>");
+					text = text === null ? '' : text.trim().replace(/(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig, "<a href='$1' target='_blank'>$1</a>");
 					entries.push({
 						identifier: identifier,
 						start: (convertSMPTEtoSeconds(timecode[1]) === 0) ? 0.200 : convertSMPTEtoSeconds(timecode[1]),


### PR DESCRIPTION
Captions files might end with a timecode line but no lines of text afterwards. This results in an error when parsing: `Uncaught TypeError: Cannot read property 'trim' of undefined`

 This change handles that case, allowing such captions files to be parsed without error. 