### PR TITLE
HTML5 Renderer: Make error event handler more robust

### DIFF
--- a/src/js/renderers/html5.js
+++ b/src/js/renderers/html5.js
@@ -138,7 +138,7 @@ const HtmlMediaElement = {
 		// Check if it current source can be played; otherwise, load next until no more options are left
 		node.addEventListener('error', function (e) {
 			// Reload the source only in case of the renderer is active at the moment
-			if (e.target.error.code === 4 && isActive) {
+			if (e && e.target && e.target.error && e.target.error.code === 4 && isActive) {
 				if (index < total && mediaFiles[(index + 1)] !== undefined) {
 					node.src = mediaFiles[index++].src;
 					node.load();


### PR DESCRIPTION
Our Sentry tracks exceptions like `TypeError: Cannot read property 'code' of null` once in a while mostly for mobile browsers on Android (and there mostly the Facebook In-App-Browser). Looks like in some edge cases e.target is no `<video>` element or it has `null` as error property instead of a `MediaError`. This commit makes the error handler check its preconditions before running. 

I was not sure whether I should have also changed the generated code. 