### PR TITLE
Changed fullscreeneventname for resolving fullscreen issue in firefox

### DIFF
--- a/src/js/utils/constants.js
+++ b/src/js/utils/constants.js
@@ -101,7 +101,7 @@ if (hasTrueNativeFullScreen) {
 	if (hasWebkitNativeFullScreen) {
 		fullScreenEventName = 'webkitfullscreenchange';
 	} else if (hasMozNativeFullScreen) {
-		fullScreenEventName = 'mozfullscreenchange';
+		fullScreenEventName = 'fullscreenchange';
 	} else if (hasMsNativeFullScreen) {
 		fullScreenEventName = 'MSFullscreenChange';
 	}


### PR DESCRIPTION
Resolved a minor issue - In Firefox browser, 'Esc' button needs to be pressed 2 times to exit fullscreen mode. This issue can be replicated in Video player demo in https://www.mediaelementjs.com/. 

Note: 'mozfullscreenchange' event works fine in the demo of github code when opened in local machine. But after hosting it doesn't work. 