### PR TITLE
Fix time slider and volume slider crash on keypress

### DIFF
--- a/src/js/features/progress.js
+++ b/src/js/features/progress.js
@@ -86,7 +86,7 @@ Object.assign(MediaElementPlayer.prototype, {
 						player.startControlsTimer();
 					}
 
-					var timeSlider = player.getElement(player.container).querySelector('.' + _player.config.classPrefix + 'time-total');
+					var timeSlider = player.getElement(player.container).querySelector(`.${t.options.classPrefix}time-total`);
 					if (timeSlider) {
 						timeSlider.focus();
 					}
@@ -110,7 +110,7 @@ Object.assign(MediaElementPlayer.prototype, {
 						player.startControlsTimer();
 					}
 
-					var timeSlider = player.getElement(player.container).querySelector('.' + _player.config.classPrefix + 'time-total');
+					var timeSlider = player.getElement(player.container).querySelector(`.${t.options.classPrefix}time-total`);
 					if (timeSlider) {
 						timeSlider.focus();
 					}

--- a/src/js/features/volume.js
+++ b/src/js/features/volume.js
@@ -135,7 +135,11 @@ Object.assign(MediaElementPlayer.prototype, {
 		{
 			keys: [77], // M
 			action: (player) => {
-				player.getElement(player.container).querySelector(`.${config.classPrefix}volume-slider`).style.display = 'block';
+				const volumeSlider = player.getElement(player.container).querySelector(`.${config.classPrefix}volume-slider`);
+				if (volumeSlider) {
+					volumeSlider.style.display = 'block';
+				}
+
 				if (player.isVideo) {
 					player.showControls();
 					player.startControlsTimer();


### PR DESCRIPTION
As a followup of #2656, this fixes the crash on left/right arrow key keypress in **Progress** where **_player** is undefined. I figure `_player.config.classPrefix` should be `t.options.classPrefix` as in the code above.
![Screen Shot 2020-01-15 at 8 58 18 AM](https://user-images.githubusercontent.com/26691304/72439635-4d8cdd00-3775-11ea-88e0-8c867b75091a.png)

As a followup of #2653, this fixes the crash on M key keypress in **Volume**. That was missed in the previous fix.
