### PR TITLE
Remove unnecessary Safari hack, fix #2526 issue

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -8,7 +8,6 @@ import DefaultPlayer from './player/default';
 import i18n from './core/i18n';
 import {
 	IS_FIREFOX,
-	IS_SAFARI,
 	IS_IPAD,
 	IS_IPHONE,
 	IS_ANDROID,
@@ -19,7 +18,7 @@ import {
 } from './utils/constants';
 import {splitEvents, isNodeAfter, createEvent, isString} from './utils/general';
 import {calculateTimeFormat} from './utils/time';
-import {getTypeFromFile, formatType} from './utils/media';
+import {getTypeFromFile} from './utils/media';
 import * as dom from './utils/dom';
 
 mejs.mepIndex = 0;
@@ -344,53 +343,6 @@ class MediaElementPlayer {
 				dom.addClass(t.getElement(t.container), `${t.options.classPrefix}iphone`);
 			}
 			dom.addClass(t.getElement(t.container), (t.isVideo ? `${t.options.classPrefix}video` : `${t.options.classPrefix}audio`));
-
-			// Workflow for Safari desktop: "clone" element and remove children, but save them to check sources, captions, etc.
-			// This ensure full compatibility when using keyboard, since Safari creates a keyboard trap when appending
-			// video/audio elements with children
-			if (IS_SAFARI && !IS_IOS) {
-
-				dom.addClass(t.getElement(t.container), `${t.options.classPrefix}hide-cues`);
-
-				const
-					cloneNode = t.node.cloneNode(),
-					children = t.node.children,
-					mediaFiles = [],
-					tracks = []
-				;
-
-				for (let i = 0, total = children.length; i < total; i++) {
-					const childNode = children[i];
-
-					switch (childNode.tagName.toLowerCase()) {
-						case 'source':
-							const elements = {};
-							Array.prototype.slice.call(childNode.attributes).forEach((item) => {
-								elements[item.name] = item.value;
-							});
-							elements.type = formatType(elements.src, elements.type);
-							mediaFiles.push(elements);
-							break;
-						case 'track':
-							childNode.mode = 'hidden';
-							tracks.push(childNode);
-							break;
-						default:
-							cloneNode.appendChild(childNode.cloneNode(true));
-							break;
-					}
-				}
-
-				t.node.remove();
-				t.node = t.media = cloneNode;
-
-				if (mediaFiles.length) {
-					t.mediaFiles = mediaFiles;
-				}
-				if (tracks.length) {
-					t.trackFiles = tracks;
-				}
-			}
 
 			// move the `video`/`audio` tag into the right spot
 			t.getElement(t.container).querySelector(`.${t.options.classPrefix}mediaelement`).appendChild(t.node);


### PR DESCRIPTION
Related to #2526 issue. I've checked Safari and ability to switch focus between different players and it seems like Safari fixed all the accessibility issues already and there is no tab/focus infinite loop when using `source` tags inside `audio` or `video` element. I recorded a video to show you the correct functionality also (as a result of this PR). 
Please, check it [here](https://cl.ly/17d489396e0f) and let me know what you think about it. Is there a need for some additional checks or researches? 
