### PR TITLE
Fix extracting the vimeo video id from private links (#2733)

### DIFF
--- a/src/js/renderers/vimeo.js
+++ b/src/js/renderers/vimeo.js
@@ -47,18 +47,35 @@ const VimeoApi = {
 	 * Valid URL format(s):
 	 *  - https://player.vimeo.com/video/59777392
 	 *  - https://vimeo.com/59777392
+	 *  - https://vimeo.com/59777392/61ee64f645
 	 *
 	 * @param {String} url - Vimeo full URL to grab the number Id of the source
 	 * @return {int}
 	 */
 	getVimeoId: (url) => {
-		if (url === undefined || url === null) {
+		if (url == null) {
 			return null;
 		}
 
 		const parts = url.split('?');
 		url = parts[0];
-		return parseInt(url.substring(url.lastIndexOf('/') + 1), 10);
+
+		const playerLinkMatch = url.match(/https:\/\/player.vimeo.com\/video\/(\d+)$/);
+		if (playerLinkMatch) {
+			return parseInt(playerLinkMatch[1], 10);
+		}
+
+		const vimeoLinkMatch = url.match(/https:\/\/vimeo.com\/(\d+)$/);
+		if (vimeoLinkMatch) {
+			return parseInt(vimeoLinkMatch[1], 10);
+		}
+
+		const privateVimeoLinkMatch = url.match(/https:\/\/vimeo.com\/(\d+)\/\w+$/);
+		if (privateVimeoLinkMatch) {
+			return parseInt(privateVimeoLinkMatch[1], 10);
+		}
+
+		return NaN;
 	}
 };
 


### PR DESCRIPTION
This PR fixes #2733.

The cause of the problem is the following:
- The `vimeoRenderer` uses the `VimeoApi.getVimeoId()` function call to determine the vimeo videoId from the url.
- This function was prepared only for the basic URL formats:
  - https://player.vimeo.com/video/59777392
  - https://vimeo.com/59777392
- Sadly, in vimeo, the private link videos use a different URL format, namely:
  - https://vimeo.com/392019292/61ee64f645
- `getVimeoId()` function is not prepared for that, it automatically tries to use the substring after the last slash character

In the fix I introduced basic regular expressions to distinguish between the different cases.