### PR TITLE
do not delay starting media on key action

### DIFF
--- a/src/js/features/progress.js
+++ b/src/js/features/progress.js
@@ -107,7 +107,7 @@ Object.assign(MediaElementPlayer.prototype, {
 					// start again to track new time
 					setTimeout(function() {
 						player.play();
-					}, 1100);
+					}, 0);
 				}
 			}
 		},
@@ -145,7 +145,7 @@ Object.assign(MediaElementPlayer.prototype, {
 					// start again to track new time
 					setTimeout(function() {
 						player.play();
-					}, 1100);
+					}, 0);
 				}
 			}
 		});


### PR DESCRIPTION
This avoids postponing play event and fixes issues with seeking by few keypresses. As a result it can result in paused media after seeking, but it is better, then providing outdated time to 'play' event. Fixed side effects for https://github.com/mediaelement/mediaelement/issues/2737