### PR TITLE
fix issues with fullscreen under Safari

### DIFF
--- a/src/js/features/fullscreen.js
+++ b/src/js/features/fullscreen.js
@@ -202,7 +202,7 @@ Object.assign(MediaElementPlayer.prototype, {
 
 		// iOS allows playing fullscreen ONLY on `video` tag, so check if the source can go fullscreen on iOS
 		// and if the player can play the current source
-		if (t.options.useFakeFullscreen === false && Features.IS_IOS && Features.HAS_IOS_FULLSCREEN &&
+		if (t.options.useFakeFullscreen === false && (Features.IS_IOS || Features.IS_SAFARI) && Features.HAS_IOS_FULLSCREEN &&
 			typeof t.media.originalNode.webkitEnterFullscreen === 'function' &&
 			t.media.originalNode.canPlayType(getTypeFromFile(t.media.getSrc()))) {
 			t.media.originalNode.webkitEnterFullscreen();


### PR DESCRIPTION
Fixes issues with running fullscreen from iframe.
In old version of mediaplayer(v2) there was no check for IOS, but only HAS_IOS_FULLSCREEN which returns true on MacOSX. Fullscreen was working correctly (when executing on video element). Now because IS_IOS was added, different if branch is executed and Safari throws fullscreen iframe policy error(when executing on mejs element). This change makes fullscreen again working for cases it was working in older versions.