### PR TITLE
get correct mime type for mov files

### DIFF
--- a/src/js/utils/media.js
+++ b/src/js/utils/media.js
@@ -78,8 +78,10 @@ export function getTypeFromFile (url) {
 
 	// Obtain correct MIME types
 	if (normalizedExt) {
-		if (~['mp4', 'm4v', 'ogg', 'ogv', 'webm', 'flv', 'mpeg', 'mov'].indexOf(normalizedExt)) {
+		if (~['mp4', 'm4v', 'ogg', 'ogv', 'webm', 'flv', 'mpeg'].indexOf(normalizedExt)) {
 			mime = `video/${normalizedExt}`;
+		} else if ('mov' === normalizedExt) {
+			mime = 'video/quicktime';
 		} else if (~['mp3', 'oga', 'wav', 'mid', 'midi'].indexOf(normalizedExt)) {
 			mime = `audio/${normalizedExt}`;
 		}


### PR DESCRIPTION
For https://github.com/mediaelement/mediaelement/issues/2765
One testcase is when using mov under IOS and trying to enter fullscreen. Than GetTypeFromFile() is executed to check if filetype is supported here https://github.com/mediaelement/mediaelement/blob/master/src/js/features/fullscreen.js#L205
Check fails because resulting mime type is 'video/mov' which is invaild mime type. This fix changes getting mime type so webkitEnterFullscreen() can be executed on originalNode.