### PR TITLE
fix: play pause async

### DIFF
--- a/src/js/core/mediaelement.js
+++ b/src/js/core/mediaelement.js
@@ -426,13 +426,13 @@ class MediaElement {
 					if (t.mediaElement.renderer !== undefined && t.mediaElement.renderer !== null &&
 						typeof t.mediaElement.renderer[methodName] === 'function') {
 						if (t.mediaElement.promises.length) {
-							Promise.all(t.mediaElement.promises).then(() => {
-								triggerAction(methodName, args);
+							return Promise.all(t.mediaElement.promises).then(() => {
+								return triggerAction(methodName, args);
 							}).catch((e) => {
 								t.mediaElement.generateError(e, mediaFiles);
 							});
 						} else {
-							triggerAction(methodName, args);
+							return triggerAction(methodName, args);
 						}
 					}
 					return null;

--- a/src/js/core/mediaelement.js
+++ b/src/js/core/mediaelement.js
@@ -430,6 +430,7 @@ class MediaElement {
 								return triggerAction(methodName, args);
 							}).catch((e) => {
 								t.mediaElement.generateError(e, mediaFiles);
+								return Promise.reject(e);
 							});
 						} else {
 							return triggerAction(methodName, args);

--- a/src/js/core/mediaelement.js
+++ b/src/js/core/mediaelement.js
@@ -412,11 +412,13 @@ class MediaElement {
 								}
 							});
 						}
+						return response
 					} else {
-						t.mediaElement.renderer[methodName](args);
+						return t.mediaElement.renderer[methodName](args);
 					}
 				} catch (e) {
 					t.mediaElement.generateError(e, mediaFiles);
+					throw e;
 				}
 			},
 			assignMethods = (methodName) => {

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1803,15 +1803,15 @@ class MediaElementPlayer {
 	}
 
 	play () {
-		this.proxy.play();
+		return this.proxy.play();
 	}
 
 	pause () {
-		this.proxy.pause();
+		return this.proxy.pause();
 	}
 
 	load () {
-		this.proxy.load();
+		return this.proxy.load();
 	}
 
 	setCurrentTime (time) {

--- a/src/js/player/default.js
+++ b/src/js/player/default.js
@@ -69,11 +69,11 @@ export default class DefaultPlayer {
 	}
 
 	play () {
-		this.media.play();
+		return this.media.play();
 	}
 
 	pause () {
-		this.media.pause();
+		return this.media.pause();
 	}
 
 	load () {


### PR DESCRIPTION
Closes #2414 

I added return statements on appropriate locations to be able to catch errors.

It's necessary to handle autoplay blocking policies on modern browsers. For example:

```js
// Autoplay
try {
  await player.play()
} catch (e) {
  console.error(e)
  // Here add logic to handle autoplay failed
  // For example: retry with muted
}
```
