### PR TITLE
feat: playUserInteraction & pauseUserInteraction

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -171,6 +171,8 @@ readyState | Return the current ready state of the audio/video | X |
 seeking | Return whether the user is currently seeking in the audio/video | X |
 src | Set or return the current source of the audio/video element | X | X
 volume | Set or return the volume of the audio/video | X | X
+playUserInteraction | Returns whether the last `play` call was initiated from user interaction | X |
+pauseUserInteraction | Returns whether the last `pause` call was initiated from user interaction | X |
 
 <a id="methods"></a>
 ### Methods

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,6 +8,7 @@
 	* [Properties](#properties)
 	* [Methods](#methods)
 	* [Events](#events)
+	* [Examples](#examples)
 
 
 <a id="attributes"></a>
@@ -212,5 +213,28 @@ pause | The media is paused either by the user or programmatically
 ended | The media has reach the end (a useful event for messages like "thanks for listening")
 volumechange | Volume is changed (including setting the volume to "mute")
 captionschange | The media has detected that captions have changed
+
+<a id="examples"></a>
+### Examples
+
+#### Detect if play/pause event comes from user interaction
+
+```js
+mediaElement.addEventListener('play', () => {
+  if (player.playUserInteraction) {
+    // Example: Send event to Websocket
+  }
+})
+
+mediaElement.addEventListener('pause', () => {
+  const userInteraction = this.player.playUserInteraction &&
+      // Handle when video is ended (dispatches a `pause` event)
+      this.player.currentTime < this.player.duration
+  if (userInteraction) {
+    // Example: Send event to Websocket
+  }
+})
+```
+
 ________
 [Back to Main](../README.md)

--- a/src/js/features/playpause.js
+++ b/src/js/features/playpause.js
@@ -50,9 +50,9 @@ Object.assign(MediaElementPlayer.prototype, {
 		play.innerHTML = `<button type="button" aria-controls="${t.id}" title="${playTitle}" aria-label="${pauseTitle}" tabindex="0"></button>`;
 		play.addEventListener('click', () => {
 			if (t.paused) {
-				t.play();
+				t.play(true);
 			} else {
-				t.pause();
+				t.pause(true);
 			}
 		});
 

--- a/src/js/features/progress.js
+++ b/src/js/features/progress.js
@@ -96,7 +96,7 @@ Object.assign(MediaElementPlayer.prototype, {
 					
 					// pause to track current time
 					if (!player.paused) {
-						player.pause();
+						player.pause(true);
 					}
 
 					// make sure time is updated after 'pause' event is processed
@@ -106,7 +106,7 @@ Object.assign(MediaElementPlayer.prototype, {
 
 					// start again to track new time
 					setTimeout(function() {
-						player.play();
+						player.play(true);
 					}, 0);
 				}
 			}
@@ -134,7 +134,7 @@ Object.assign(MediaElementPlayer.prototype, {
 					
 					// pause to track current time
 					if (!player.paused) {
-						player.pause();
+						player.pause(true);
 					}
 
 					// make sure time is updated after 'pause' event is processed
@@ -144,7 +144,7 @@ Object.assign(MediaElementPlayer.prototype, {
 
 					// start again to track new time
 					setTimeout(function() {
-						player.play();
+						player.play(true);
 					}, 0);
 				}
 			}
@@ -343,7 +343,7 @@ Object.assign(MediaElementPlayer.prototype, {
 				}
 				if (t.forcedHandlePause) {
 					t.slider.focus();
-					t.play();
+					t.play(true);
 				}
 				t.forcedHandlePause = false;
 			}
@@ -416,9 +416,9 @@ Object.assign(MediaElementPlayer.prototype, {
 					case 32: // space
 						if (IS_FIREFOX) {
 							if (t.paused) {
-								t.play();
+								t.play(true);
 							} else {
-								t.pause();
+								t.pause(true);
 							}
 						}
 						return;
@@ -429,7 +429,7 @@ Object.assign(MediaElementPlayer.prototype, {
 				seekTime = seekTime < 0 || isNaN(seekTime) ? 0 : (seekTime >= duration ? duration : Math.floor(seekTime));
 				lastKeyPressTime = new Date();
 				if (!startedPaused) {
-					player.pause();
+					player.pause(true);
 				}
 
 				// make sure time is updated after 'pause' event is processed
@@ -460,7 +460,7 @@ Object.assign(MediaElementPlayer.prototype, {
 					// only handle left clicks or touch
 					if (e.which === 1 || e.which === 0) {
 						if (!t.paused) {
-							t.pause();
+							t.pause(true);
 							t.forcedHandlePause = true;
 						}
 

--- a/src/js/features/tracks.js
+++ b/src/js/features/tracks.js
@@ -731,7 +731,7 @@ Object.assign(MediaElementPlayer.prototype, {
 
 				t.media.setCurrentTime(parseFloat(self.value));
 				if (t.media.paused) {
-					t.media.play();
+					t.media.play(true);
 				}
 			});
 		}

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -130,12 +130,11 @@ export const config = {
 				179 // GOOGLE play/pause button
 			],
 			action: (player) => {
-
 				if (!IS_FIREFOX) {
 					if (player.paused || player.ended) {
-						player.play();
+						player.play(true);
 					} else {
-						player.pause();
+						player.pause(true);
 					}
 				}
 			}
@@ -656,11 +655,11 @@ class MediaElementPlayer {
 						;
 
 						if (t.paused && pressed) {
-							t.pause();
+							t.pause(true);
 						} else if (t.paused) {
-							t.play();
+							t.play(true);
 						} else {
-							t.pause();
+							t.pause(true);
 						}
 
 						button.setAttribute('aria-pressed', !(pressed));
@@ -1358,9 +1357,9 @@ class MediaElementPlayer {
 			layer.addEventListener('click', (e) => {
 				if (t.options.clickToPlayPause) {
 					if (t.paused) {
-						t.play();
+						t.play(true);
 					} else {
-						t.pause();
+						t.pause(true);
 					}
 
 					e.preventDefault();
@@ -1596,9 +1595,9 @@ class MediaElementPlayer {
 				;
 
 				if (t.paused) {
-					t.play();
+					t.play(true);
 				} else {
-					t.pause();
+					t.pause(true);
 				}
 
 				button.setAttribute('aria-pressed', !!pressed);
@@ -1802,11 +1801,13 @@ class MediaElementPlayer {
 		return this.getSrc();
 	}
 
-	play () {
+	play (userInteraction = false) {
+		this.playUserInteraction = userInteraction;
 		this.proxy.play();
 	}
 
-	pause () {
+	pause (userInteraction = false) {
+		this.pauseUserInteraction = userInteraction;
 		this.proxy.pause();
 	}
 


### PR DESCRIPTION
Added two new properties to `MediaElementPlayer` (with docs):

- `playUserInteraction`: Returns whether the last `play` call was initiated from user interaction
- `pauseUserInteraction`: Returns whether the last `pause` call was initiated from user interaction

Example usage (for example to synchronize video events over Websockets):

```js
mediaElement.addEventListener('play', () => {
  if (player.playUserInteraction) {
    // Example: Send event to Websocket
  }
})

mediaElement.addEventListener('pause', () => {
  const userInteraction = this.player.playUserInteraction &&
      // Handle when video is ended (dispatches a `pause` event)
      this.player.currentTime < this.player.duration
  if (userInteraction) {
    // Example: Send event to Websocket
  }
})
```