### PR TITLE
fix(flash hls): send correct error message

### DIFF
--- a/src/flash/flash-video-hls/HlsMediaElement.as
+++ b/src/flash/flash-video-hls/HlsMediaElement.as
@@ -323,7 +323,7 @@
 			sendEvent('ended');
 		}
 		private function _errorHandler(event: HLSEvent): void {
-			sendEvent('error', event.toString());
+			sendEvent('error', event.error.toString());
 		}
 		private function _levelLoadingHandler(event: HLSEvent): void {
 			sendEvent('onLevelLoading', JSON.stringify(event));


### PR DESCRIPTION
Instead of receiving a generic `[Error ...]` message with no details on the actual error, the JS part now receives the original error message from FlashHLS:

```
HLSError(code/url/msg)=1/https://acme.com/playlist.m3u8/Cannot load M3U8: crossdomain access denied:Error #2048
```