### PR TITLE
Make controls bar stick when hovering

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -466,7 +466,7 @@ class MediaElementPlayer {
 			(t.paused && t.readyState === 4 && ((!t.options.hideVideoControlsOnLoad &&
 			t.currentTime <= 0) || (!t.options.hideVideoControlsOnPause && t.currentTime > 0))) ||
 			(t.isVideo && !t.options.hideVideoControlsOnLoad && !t.readyState) ||
-			t.ended)) {
+			t.ended || t.controls.matches(':hover'))) {
 			return;
 		}
 


### PR DESCRIPTION
When playing a video file, the controls bar always get hidden after sometime.
In other media players, when the user hover over the controls it doesn't get hidden since it gives the user the ability to seek and observe the current time.