### PR TITLE
Play/pause player with spacebar in Firefox

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -130,13 +130,10 @@ export const config = {
 				179 // GOOGLE play/pause button
 			],
 			action: (player) => {
-
-				if (!IS_FIREFOX) {
-					if (player.paused || player.ended) {
-						player.play();
-					} else {
-						player.pause();
-					}
+				if (player.paused || player.ended) {
+					player.play();
+				} else {
+					player.pause();
 				}
 			}
 		}


### PR DESCRIPTION
When the player is focused the user can use `spacebar` to play/pause it in Chrome and Safari but not in Firefox. This PR fixes that.