### PR TITLE
docs: Fix simple typo, refereces -> references

### DIFF
--- a/src/flash/flash-audio-ogg/flacc/oggvorbis.c
+++ b/src/flash/flash-audio-ogg/flacc/oggvorbis.c
@@ -416,7 +416,7 @@ int main() {
 	AS3_Val getPositionVal = AS3_Function(NULL, getPosition);
 	AS3_Val seekVal = AS3_Function(NULL, seek);
 
-	// construct an object that holds refereces to the 2 functions
+	// construct an object that holds references to the 2 functions
 	AS3_Val result = AS3_Object("version:StrType", versionVal);
 	AS3_SetS(result, "setupDecoder", setupDecoderVal);
 	AS3_SetS(result, "getHeader", getHeaderVal);


### PR DESCRIPTION
There is a small typo in src/flash/flash-audio-ogg/flacc/oggvorbis.c.

Should read `references` rather than `refereces`.

