### PR TITLE
Fix for w3c validation error in volume slider

### DIFF
--- a/src/js/features/volume.js
+++ b/src/js/features/volume.js
@@ -78,7 +78,7 @@ Object.assign(MediaElementPlayer.prototype, {
 		mute.innerHTML = mode === 'horizontal' ?
 			`<button type="button" aria-controls="${t.id}" title="${muteText}" aria-label="${muteText}" tabindex="0"></button>` :
 			`<button type="button" aria-controls="${t.id}" title="${muteText}" aria-label="${muteText}" tabindex="0"></button>` +
-			`<a href="javascript:void(0);" class="${t.options.classPrefix}volume-slider" ` +
+			`<a class="${t.options.classPrefix}volume-slider" ` +
 				`aria-label="${i18n.t('mejs.volume-slider')}" aria-valuemin="0" aria-valuemax="100" role="slider" ` +
 				`aria-orientation="vertical">` +
 				`<span class="${t.options.classPrefix}offscreen">${volumeControlText}</span>` +
@@ -156,7 +156,6 @@ Object.assign(MediaElementPlayer.prototype, {
 		if (mode === 'horizontal') {
 			const anchor = document.createElement('a');
 			anchor.className = `${t.options.classPrefix}horizontal-volume-slider`;
-			anchor.href = 'javascript:void(0);';
 			anchor.setAttribute('aria-label', i18n.t('mejs.volume-slider'));
 			anchor.setAttribute('aria-valuemin', 0);
 			anchor.setAttribute('aria-valuemax', 100);


### PR DESCRIPTION
This pull request fixes the error mentioned in
https://github.com/mediaelement/mediaelement/issues/2801

Short summary:
The Nu Html Checker (https://validator.w3.org/nu/about.html) which does not check the source code but the generated code ("Check serialized DOM of current page") throws the error message "Attribute href not allowed on element a at this point." It's in the volume slider, where href ist not allowed in an element with role="slider".

In this pull request the href="javascript:void(0)" is removed from vertical and horizontal volume sliders.
