### PR TITLE
Replace `javascript:` URIs with event handlers.

### DIFF
--- a/src/js/features/volume.js
+++ b/src/js/features/volume.js
@@ -78,7 +78,7 @@ Object.assign(MediaElementPlayer.prototype, {
 		mute.innerHTML = mode === 'horizontal' ?
 			`<button type="button" aria-controls="${t.id}" title="${muteText}" aria-label="${muteText}" tabindex="0"></button>` :
 			`<button type="button" aria-controls="${t.id}" title="${muteText}" aria-label="${muteText}" tabindex="0"></button>` +
-			`<a href="javascript:void(0);" class="${t.options.classPrefix}volume-slider" ` +
+			`<a href="about:blank" class="${t.options.classPrefix}volume-slider" ` +
 				`aria-label="${i18n.t('mejs.volume-slider')}" aria-valuemin="0" aria-valuemax="100" role="slider" ` +
 				`aria-orientation="vertical">` +
 				`<span class="${t.options.classPrefix}offscreen">${volumeControlText}</span>` +
@@ -89,6 +89,13 @@ Object.assign(MediaElementPlayer.prototype, {
 			`</a>`;
 
 		t.addControlElement(mute, 'volume');
+
+		const volumeSliderElement = mute.querySelector(`.${t.options.classPrefix}volume-slider`);
+		if (volumeSliderElement !== null) {
+			volumeSliderElement.addEventListener('click', function (event) {
+				event.preventDefault()
+			});
+		}
 
 		t.options.keyActions.push({
 			keys: [38], // UP
@@ -156,12 +163,15 @@ Object.assign(MediaElementPlayer.prototype, {
 		if (mode === 'horizontal') {
 			const anchor = document.createElement('a');
 			anchor.className = `${t.options.classPrefix}horizontal-volume-slider`;
-			anchor.href = 'javascript:void(0);';
+			anchor.href = 'about:blank';
 			anchor.setAttribute('aria-label', i18n.t('mejs.volume-slider'));
 			anchor.setAttribute('aria-valuemin', 0);
 			anchor.setAttribute('aria-valuemax', 100);
 			anchor.setAttribute('aria-valuenow', 100);
 			anchor.setAttribute('role', 'slider');
+			anchor.addEventListener('click', function (event) {
+				event.preventDefault();
+			});
 			anchor.innerHTML += `<span class="${t.options.classPrefix}offscreen">${volumeControlText}</span>` +
 				`<div class="${t.options.classPrefix}horizontal-volume-total">` +
 				`<div class="${t.options.classPrefix}horizontal-volume-current"></div>` +


### PR DESCRIPTION
Description of Changes:
* Refactor of `javascript:` URIs generated by `buildvolume` in `src/js/features/volume.js` to enable [**strict CSP**-compatibility](https://csp.withgoogle.com/docs/adopting-csp.html).

Why:
Content Security Policy is a mechanism designed to make applications more secure against common web vulnerabilities, particularly cross-site scripting. It is enabled by setting the Content-Security-Policy HTTP response header.
An application can add a critical defense-in-depth layer against markup injection attacks by adopting a strict policy that prevents the loading of untrusted scripts or plugins.
To make an application compatible with strict CSP, it is necessary to make changes to HTML templates and client-side code and add the policy header:

1. Add nonces to <script> elements;
2. Refactor inline event handlers and javascript: URIs;
3. Refactor calls to JS APIs incompatible with CSP;
4. Serve the Content-Security-Policy header.

[More on CSP.](https://csp.withgoogle.com/)

This PR is related to a series of efforts to make WordPress strict CSP compatible, more on that [here](https://core.trac.wordpress.org/ticket/51407).