### PR TITLE
Added check that target.closest is a function in mousemov.vol code

### DIFF
--- a/src/js/features/volume.js
+++ b/src/js/features/volume.js
@@ -393,8 +393,9 @@ Object.assign(MediaElementPlayer.prototype, {
 			t.globalBind('mousemove.vol', (event) => {
 				const target = event.target;
 				if (mouseIsDown && (target === volumeSlider ||
+                                        (typeof target.closest == 'function' && 
 					target.closest((mode === 'vertical' ? `.${t.options.classPrefix}volume-slider` :
-					`.${t.options.classPrefix}horizontal-volume-slider`)))) {
+					`.${t.options.classPrefix}horizontal-volume-slider`))))) {
 					handleVolumeMove(event);
 				}
 			});


### PR DESCRIPTION
This fixes #2839.

This checks if the ```target``` object as the ```closest``` function before calling it, avoid the error in the issue.