### PR TITLE
Add null check to document.activeElement

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1714,6 +1714,10 @@ class MediaElementPlayer {
 		});
 
 		t.globalKeydownCallback = (event) => {
+			if (!document.activeElement) { 
+				return true;
+			}
+			
 			const
 				container = document.activeElement.closest(`.${t.options.classPrefix}container`),
 				target = t.media.closest(`.${t.options.classPrefix}container`)


### PR DESCRIPTION
document.activeElement can be null. When it is and key is pressed, an exception is thrown.
https://developer.mozilla.org/en-US/docs/Web/API/Document/activeElement

I propose to do a null check before the .closest() call.