### PR TITLE
Fix #2870 - scope 'use strict' of languages files

### DIFF
--- a/src/js/languages/ca.js
+++ b/src/js/languages/ca.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*!
  * This is a `i18n` language object.
  *
@@ -11,6 +9,8 @@
  * @see core/i18n.js
  */
 (function (exports) {
+    'use strict';
+
 	if (exports.ca === undefined) {
 		exports.ca = {
 			'mejs.plural-form': 1,

--- a/src/js/languages/cs.js
+++ b/src/js/languages/cs.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*!
  * This is a `i18n` language object.
  *
@@ -12,6 +10,8 @@
  * @see core/i18n.js
  */
 (function (exports) {
+    'use strict';
+
 	if (exports.cs === undefined) {
 		exports.cs = {
 			'mejs.plural-form': 8,

--- a/src/js/languages/de.js
+++ b/src/js/languages/de.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*!
  * This is a `i18n` language object.
  *
@@ -12,6 +10,8 @@
  * @see core/i18n.js
  */
 (function (exports) {
+    'use strict';
+
 	if (exports.de === undefined) {
 		exports.de = {
 			'mejs.plural-form': 1,

--- a/src/js/languages/es.js
+++ b/src/js/languages/es.js
@@ -10,8 +10,9 @@
  *
  * @see core/i18n.js
  */
-
 (function (exports) {
+    'use strict';
+
 	if (exports.es === undefined) {
 		exports.es = {
 			'mejs.plural-form': 1,

--- a/src/js/languages/fa.js
+++ b/src/js/languages/fa.js
@@ -8,7 +8,6 @@
  *
  * @see core/i18n.js
  */
-
 (function (exports) {
     'use strict';
     

--- a/src/js/languages/fr.js
+++ b/src/js/languages/fr.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*!
  * This is a `i18n` language object.
  *
@@ -13,6 +11,8 @@
  * @see core/i18n.js
  */
 (function (exports) {
+    'use strict';
+
 	if (exports.fr === undefined) {
 		exports.fr = {
 			'mejs.plural-form': 2,

--- a/src/js/languages/hr.js
+++ b/src/js/languages/hr.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*!
  * This is a `i18n` language object.
  *
@@ -11,6 +9,8 @@
  * @see core/i18n.js
  */
 (function (exports) {
+    'use strict';
+
 	if (exports.hr === undefined) {
 		exports.hr = {
 			'mejs.plural-form': 7,

--- a/src/js/languages/hu.js
+++ b/src/js/languages/hu.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*!
  * This is a `i18n` language object.
  *
@@ -12,6 +10,8 @@
  * @see core/i18n.js
  */
 (function (exports) {
+    'use strict';
+
 	if (exports.hu === undefined) {
 		exports.hu = {
 			'mejs.plural-form': 1,

--- a/src/js/languages/it.js
+++ b/src/js/languages/it.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*!
  * This is a `i18n` language object.
  *
@@ -12,6 +10,8 @@
  * @see core/i18n.js
  */
 (function (exports) {
+    'use strict';
+
 	if (exports.it === undefined) {
 		exports.it = {
 			'mejs.plural-form': 1,

--- a/src/js/languages/ja.js
+++ b/src/js/languages/ja.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*!
  * This is a `i18n` language object.
  *
@@ -12,6 +10,8 @@
  * @see core/i18n.js
  */
 (function (exports) {
+    'use strict';
+
 	if (exports.ja === undefined) {
 		exports.ja = {
 			'mejs.plural-form': 0,

--- a/src/js/languages/ko.js
+++ b/src/js/languages/ko.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*!
  * This is a `i18n` language object.
  *
@@ -12,6 +10,8 @@
  * @see core/i18n.js
  */
 (function (exports) {
+    'use strict';
+
 	if (exports.ko === undefined) {
 		exports.ko = {
 			'mejs.plural-form': 0,

--- a/src/js/languages/ms.js
+++ b/src/js/languages/ms.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*!
  * This is a `i18n` language object.
  *
@@ -12,6 +10,8 @@
  * @see core/i18n.js
  */
 (function (exports) {
+    'use strict';
+
 	if (exports.ms === undefined) {
 		exports.ms = {
 			'mejs.plural-form': 0,

--- a/src/js/languages/nl.js
+++ b/src/js/languages/nl.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*!
  * This is a `i18n` language object.
  *
@@ -13,6 +11,8 @@
  * @see core/i18n.js
  */
 (function (exports) {
+    'use strict';
+
 	if (exports.nl === undefined) {
 		exports.nl = {
 			'mejs.plural-form': 1,

--- a/src/js/languages/pl.js
+++ b/src/js/languages/pl.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*!
  * This is a `i18n` language object.
  *
@@ -12,6 +10,8 @@
  * @see core/i18n.js
  */
 (function (exports) {
+    'use strict';
+
 	if (exports.pl === undefined) {
 		exports.pl = {
 			'mejs.plural-form': 9,

--- a/src/js/languages/pt.js
+++ b/src/js/languages/pt.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*!
  * This is a `i18n` language object.
  *
@@ -12,6 +10,8 @@
  * @see core/i18n.js
  */
 (function (exports) {
+    'use strict';
+
 	if (exports.pt === undefined) {
 		exports.pt = {
 			'mejs.plural-form': 1,

--- a/src/js/languages/ro.js
+++ b/src/js/languages/ro.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*!
  * This is a `i18n` language object.
  *
@@ -12,6 +10,8 @@
  * @see core/i18n.js
  */
 (function (exports) {
+    'use strict';
+
 	if (exports.ro === undefined) {
 		exports.ro = {
 			'mejs.plural-form': 5,

--- a/src/js/languages/ru.js
+++ b/src/js/languages/ru.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*!
  * This is a `i18n` language object.
  *
@@ -12,6 +10,8 @@
  * @see core/i18n.js
  */
 (function (exports) {
+    'use strict';
+
 	if (exports.ru === undefined) {
 		exports.ru = {
 			'mejs.plural-form': 7,

--- a/src/js/languages/sk.js
+++ b/src/js/languages/sk.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*!
  * This is a `i18n` language object.
  *
@@ -12,6 +10,8 @@
  * @see core/i18n.js
  */
 (function (exports) {
+    'use strict';
+
 	if (exports.sk === undefined) {
 		exports.sk = {
 			'mejs.plural-form': 8,

--- a/src/js/languages/sv.js
+++ b/src/js/languages/sv.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*!
  * This is a `i18n` language object.
  *
@@ -11,6 +9,8 @@
  * @see core/i18n.js
  */
 (function (exports) {
+    'use strict';
+
 	if (exports.sv === undefined) {
 		exports.sv = {
 			'mejs.plural-form': 1,

--- a/src/js/languages/tr.js
+++ b/src/js/languages/tr.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*!
  * This is a `i18n` language object.
  *
@@ -12,6 +10,8 @@
  * @see core/i18n.js
  */
 (function (exports) {
+    'use strict';
+
     if (exports.tr === undefined) {
         exports.tr = {
             'mejs.plural-form': 1,

--- a/src/js/languages/uk.js
+++ b/src/js/languages/uk.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*!
  * This is a `i18n` language object.
  *
@@ -11,6 +9,8 @@
  * @see core/i18n.js
  */
 (function (exports) {
+    'use strict';
+
 	if (exports.uk === undefined) {
 		exports.uk = {
 			'mejs.plural-form': 7,

--- a/src/js/languages/zh-cn.js
+++ b/src/js/languages/zh-cn.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*!
  * This is a `i18n` language object.
  *
@@ -12,6 +10,8 @@
  * @see core/i18n.js
  */
 (function (exports) {
+    'use strict';
+
 	if (exports['zh-CN'] === undefined) {
 		exports['zh-CN'] = {
 			'mejs.plural-form': 0,

--- a/src/js/languages/zh.js
+++ b/src/js/languages/zh.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*!
  * This is a `i18n` language object.
  *
@@ -13,6 +11,8 @@
  * @see core/i18n.js
  */
 (function (exports) {
+    'use strict';
+
 	if (exports.zh === undefined) {
 		exports.zh = {
 			'mejs.plural-form': 0,


### PR DESCRIPTION
Move all "use strict" inside function scope (excepted for the en.js file which is bundled) to prevent any side effect.