### PR TITLE
Bugfix: Removing double negation to correctly reflect the aria-pressed status…

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1607,7 +1607,7 @@ class MediaElementPlayer {
 					t.pause();
 				}
 
-				button.setAttribute('aria-pressed', !!pressed);
+				button.setAttribute('aria-pressed', !pressed);
 				t.getElement(t.container).focus();
 			}
 		});


### PR DESCRIPTION
… of the big play button when clicked for the first time.

Currently, when clicked for the first time on V5.0.0, the big play button doesn´t reflect the aria-pressed status (true) correctly. This just happens when being hit for the second time 