### PR TITLE
Fix for aria-pressed state and minimizing necessary tabs

### DIFF
--- a/src/js/core/mediaelement.js
+++ b/src/js/core/mediaelement.js
@@ -91,6 +91,9 @@ class MediaElement {
 			t.mediaElement.originalNode.setAttribute('preload', 'none');
 		}
 
+		// prevent audio/video containers from getting focused
+		t.mediaElement.originalNode.setAttribute('tabindex', -1);
+
 		// add next to this one
 		t.mediaElement.originalNode.parentNode.insertBefore(t.mediaElement, t.mediaElement.originalNode);
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -648,7 +648,6 @@ class MediaElementPlayer {
 				// create callback here since it needs access to current
 				// MediaElement object
 				t.clickToPlayPauseCallback = () => {
-
 					if (t.options.clickToPlayPause) {
 						const
 							button = t.getElement(t.container)
@@ -664,7 +663,7 @@ class MediaElementPlayer {
 							t.pause();
 						}
 
-						button.setAttribute('aria-pressed', !(pressed));
+						button.setAttribute('aria-pressed', !pressed);
 						t.getElement(t.container).focus();
 					}
 				};
@@ -1589,7 +1588,7 @@ class MediaElementPlayer {
 		layers.appendChild(error);
 
 		bigPlay.className = `${t.options.classPrefix}overlay ${t.options.classPrefix}layer ${t.options.classPrefix}overlay-play`;
-		bigPlay.innerHTML = generateControlButton(t.id, i18n.t('mejs.play'), i18n.t('mejs.play'), `${t.media.options.iconSprite}`,['icon-overlay-play'], `${t.options.classPrefix}`, `${t.options.classPrefix}overlay-button`);
+		bigPlay.innerHTML = generateControlButton(t.id, i18n.t('mejs.play'), i18n.t('mejs.play'), `${t.media.options.iconSprite}`,['icon-overlay-play'], `${t.options.classPrefix}`, `${t.options.classPrefix}overlay-button`, '', false);
 
 		bigPlay.addEventListener('click', () => {
 			// Removed 'touchstart' due issues on Samsung Android devices where a tap on bigPlay

--- a/src/js/utils/generate.js
+++ b/src/js/utils/generate.js
@@ -15,7 +15,7 @@ import mejs from '../core/mejs';
  * @param {String} ariaDescribedby id for aria-describedby attribute
  * @return {String}
  */
-export function generateControlButton (playerId, ariaLabel, title, iconSprite, icons, classPrefix, buttonClass = null, ariaDescribedby= '') {
+export function generateControlButton (playerId, ariaLabel, title, iconSprite, icons, classPrefix, buttonClass = null, ariaDescribedby= '', ariaPressed = null) {
 
 	if (typeof playerId !== 'string') {
 		throw new Error('`ariaControls` argument must be a string');
@@ -43,13 +43,15 @@ export function generateControlButton (playerId, ariaLabel, title, iconSprite, i
 
 	const ariaDescribedbyAttr = ariaDescribedby !== '' ? `aria-describedby="${ariaDescribedby}" ` : '';
 
+	const ariaPressedAttr = ariaPressed !== null ?  `aria-pressed="${ariaPressed}"` : '';
+
 	const iconHtml = icons.map(icon => {
 		return `<svg xmlns="http://www.w3.org/2000/svg" id="${playerId}-${icon}" class="${classPrefix}${icon}" aria-hidden="true" focusable="false">
 				<use xlink:href="${iconSprite}#${icon}"></use>
 			</svg>
 `	})
 
-	return `<button ${className} aria-controls="${playerId}" title="${title}" aria-label="${ariaLabel}" ${ariaDescribedbyAttr}>
+	return `<button ${className} aria-controls="${playerId}" title="${title}" aria-label="${ariaLabel}" ${ariaDescribedbyAttr} ${ariaPressedAttr}>
 			${iconHtml.join('')}
 		</button>`;
 }


### PR DESCRIPTION
* Reflect correct aria-pressed status of overlay play button when clicked for the first time
* Reflect toggling aria-pressed statusof the overlay play button correctly
* Minimizing necessary tabs for Firefox by setting audio/video-element to tabindex="-1"