### PR TITLE
Insert type of the button back

### DIFF
--- a/src/js/utils/generate.js
+++ b/src/js/utils/generate.js
@@ -51,7 +51,7 @@ export function generateControlButton (playerId, ariaLabel, title, iconSprite, i
 			</svg>
 `	})
 
-	return `<button ${className} aria-controls="${playerId}" title="${title}" aria-label="${ariaLabel}" ${ariaDescribedbyAttr} ${ariaPressedAttr}>
+	return `<button ${className} type="button" aria-controls="${playerId}" title="${title}" aria-label="${ariaLabel}" ${ariaDescribedbyAttr} ${ariaPressedAttr}>
 			${iconHtml.join('')}
 		</button>`;
 }


### PR DESCRIPTION
Since some browsers will think a button without a type is by default a submit button and since this method is used to create the play/pause button, the volume button, any button really, those buttons will as a result submit any form the player is sitting in. Not really a preferred behavior.