### PR TITLE
Add empty alt to poster image

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1380,6 +1380,7 @@ class MediaElementPlayer {
 
 			if (!posterImg && url) {
 				posterImg = document.createElement('img');
+				posterImg.alt = '';
 				posterImg.className = `${t.options.classPrefix}poster-img`;
 				posterImg.width = '100%';
 				posterImg.height = '100%';


### PR DESCRIPTION
Screen readers currently read the poster image url. Also, automated accessibility tests flag all posters as "image without a text alternative." The empty alt marks the poster as decorative so it is skipped by screen readers and satisfies automated tests.