### PR TITLE
Added new option to hide screen reader title

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -138,6 +138,7 @@ captionTextPreprocessor | function | _not set_ | Option to preprocess the captio
 toggleCaptionsButtonWhenOnlyOne | boolean | `false` | If true and we only have one track, change captions to toggle button
 startLanguage | string | _(empty)_ | Automatically turn on a `<track>` element. Note: Will not work when toggleCaptionsButtonWhenOnlyOne is set to `true`
 slidesSelector | string | _(empty)_ | Selector for slides; could be any valid JavaScript selector (`#id`, `.class`, `img`, etc.)
+hideScreenReaderTitle | boolean | false | Hide the video player screen reader title so it can be added by the website
 tracksText | string | `null` | Title for Closed Captioning button for WARIA purposes
 chaptersText  | string | `null` | Title for Chapters button for WARIA purposes
 muteText | string | `null` | Title for Mute button for WARIA purposes

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -124,7 +124,9 @@ export const config = {
 	// If error happens, set up HTML message via string or function
 	customError: null,
 	// Array of keyboard actions such as play/pause
-	keyActions: []
+	keyActions: [],
+	// Hide WAI-ARIA video player title so it can be added externally on the website
+	hideScreenReaderTitle: false
 };
 
 mejs.MepDefaults = config;
@@ -262,10 +264,12 @@ class MediaElementPlayer {
 			t.node.removeAttribute('controls');
 			const videoPlayerTitle = t.isVideo ? i18n.t('mejs.video-player') : i18n.t('mejs.audio-player');
 			// insert description for screen readers
-			const offscreen = document.createElement('span');
-			offscreen.className = `${t.options.classPrefix}offscreen`;
-			offscreen.innerText = videoPlayerTitle;
-			t.media.parentNode.insertBefore(offscreen, t.media);
+			if (!t.options.hideScreenReaderTitle) {
+				const offscreen = document.createElement('span');
+				offscreen.className = `${t.options.classPrefix}offscreen`;
+				offscreen.innerText = videoPlayerTitle;
+				t.media.parentNode.insertBefore(offscreen, t.media);
+			}
 
 			// build container
 			t.container = document.createElement('div');


### PR DESCRIPTION
A new option has been added to hide the screen reader title so a title can be added by the website without being read twice.