### PR TITLE
fixed forcefully exit fullscreen on zoom

### DIFF
--- a/src/js/features/fullscreen.js
+++ b/src/js/features/fullscreen.js
@@ -229,7 +229,8 @@ Object.assign(MediaElementPlayer.prototype, {
 					if (t.isNativeFullScreen) {
 						let percentErrorMargin = 0.002, // 0.2%
 							windowWidth = window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth,
-							screenWidth = screen.width,
+							resizeRatio = window.innerWidth / window.screen.availWidth,
+							screenWidth = screen.width * resizeRatio,
 							absDiff = Math.abs(screenWidth - windowWidth),
 							marginError = screenWidth * percentErrorMargin;
 


### PR DESCRIPTION
fixed :https://github.com/mediaelement/mediaelement/issues/2919