### PR TITLE
Added outline-style in CSS for focused elements

### DIFF
--- a/src/css/mediaelementplayer.css
+++ b/src/css/mediaelementplayer.css
@@ -51,6 +51,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 
 .mejs__container:focus {
     outline-offset: 0.125rem;
+    outline-style: auto;
     outline-width: 0.125rem;
 }
 


### PR DESCRIPTION
Added `outline-style` property in CSS to fix `outline-color` on focus in Firefox, if defined.