### PR TITLE
Outline-style changed from "auto" to "solid"

### DIFF
--- a/src/css/mediaelementplayer.css
+++ b/src/css/mediaelementplayer.css
@@ -51,7 +51,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 
 .mejs__container:focus {
     outline-offset: 0.125rem;
-    outline-style: auto;
+    outline-style: solid;
     outline-width: 0.125rem;
 }
 


### PR DESCRIPTION
`Outline-style` needs to be other than auto to enable Firefox and Safari to show the right `outline-color` on focus.