### PR TITLE
fix captions toggle not showing state

### DIFF
--- a/src/css/mediaelementplayer-legacy.css
+++ b/src/css/mediaelementplayer-legacy.css
@@ -614,6 +614,15 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
     width: 5.375rem;
 }
 
+/* reduced opacity if captions button is in toggle mode and deactivated */
+.mejs-captions-button-toggle {
+    opacity: 0.7;
+}
+/* normal opacity if captions button is in toggle mode and activated */
+.mejs-captions-button-toggle-on {
+    opacity: 1;
+}
+
 .mejs-chapters-button > .mejs-chapters-selector {
     margin-right: -3.4375rem;
     width: 6.875rem;

--- a/src/css/mediaelementplayer.css
+++ b/src/css/mediaelementplayer.css
@@ -613,6 +613,15 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
     width: 5.375rem;
 }
 
+/* reduced opacity if captions button is in toggle mode and deactivated */
+.mejs__captions-button-toggle {
+    opacity: 0.7;
+}
+/* normal opacity if captions button is in toggle mode and activated */
+.mejs__captions-button-toggle-on {
+    opacity: 1;
+}
+
 .mejs__chapters-button > .mejs__chapters-selector {
     margin-right: -3.4375rem;
     width: 6.875rem;

--- a/src/js/features/tracks.js
+++ b/src/js/features/tracks.js
@@ -146,6 +146,7 @@ Object.assign(MediaElementPlayer.prototype, {
 
     // if only one language then just make the button a toggle
     if (t.options.toggleCaptionsButtonWhenOnlyOne && subtitles.length === 1) {
+      player.captionsButton.classList.add(`${t.options.classPrefix}captions-button-toggle`);
       player.captionsButton.addEventListener('click', (e) => {
         let trackId = 'none';
         if (player.selectedTrack === null) {
@@ -510,6 +511,10 @@ Object.assign(MediaElementPlayer.prototype, {
         }
       }
     }
+    if (this.options.toggleCaptionsButtonWhenOnlyOne && this.getSubtitles().length === 1) {
+      // deactivate captions toggle button
+      this.captionsButton.classList.remove(`${this.options.classPrefix}captions-button-toggle-on`);
+    }
   },
 
   /**
@@ -524,6 +529,10 @@ Object.assign(MediaElementPlayer.prototype, {
       if (track.kind === 'subtitles' || track.kind === 'captions') {
         if (track.language === srclang) {
           track.mode = 'showing';
+          if (this.options.toggleCaptionsButtonWhenOnlyOne && this.getSubtitles().length === 1) {
+            // activate captions toggle button
+            this.captionsButton.classList.add(`${this.options.classPrefix}captions-button-toggle-on`);
+          }
         } else {
           track.mode = 'hidden';
         }


### PR DESCRIPTION
When _**toggleCaptionsButtonWhenOnlyOne**_ is set, the captions button does not show the current state (captions active/inactive). This fixes that problem by giving the button a slightly transparent look if it is a toggle and inactive.