### PR TITLE
Fix for captions and mpeg-dash and hls

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>MediaElement.js 4.2.x - audio/video unification library</title>
+    <title>MediaElement.js - audio/video unification library</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
     <link rel="icon" href="favicon.ico" type="image/x-icon">
@@ -57,6 +57,14 @@
             left: 0;
             width: 12px;
             height: 12px;
+        }
+
+        .details {
+            margin-bottom: 24px;
+        }
+
+        .players {
+            max-width: 800px;
         }
     </style>
 </head>
@@ -116,13 +124,15 @@
         </section>
 
         <br>
+
+        <!-- VIDEOPLAYER -->
         <div class="players" id="player1-container">
 
             <h3>Video Player</h3>
 
             <div class="media-wrapper">
                 <video id="player1" width="640" height="360" style="max-width:100%;" poster="http://www.mediaelementjs.com/images/big_buck_bunny.jpg" preload="none" controls playsinline webkit-playsinline>
-                    <source src="https://commondatastorage.googleapis.com/gtv-videos-bucket/CastVideos/mp4/BigBuckBunny.mp4" type="video/mp4">
+                    <source src="//github.com/mediaelement/mediaelement-files/blob/master/big_buck_bunny.mp4?raw=true" type="video/mp4">
                     <track srclang="de" kind="subtitles" src="german.vtt" label="German with lines">
                     <track srclang="en" kind="subtitles" src="english.vtt" default>
                     <track srclang="en" kind="chapters" src="english_chapters.vtt">
@@ -136,7 +146,7 @@
                     <option value="//github.com/mediaelement/mediaelement-files/blob/master/big_buck_bunny.mp4?raw=true">MP4</option>
                     <option value="//upload.wikimedia.org/wikipedia/commons/2/22/Volcano_Lava_Sample.webm">WebM</option>
                     <option value="https://bitdash-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8">HLS</option>
-                    <option value="//www.bok.net/dash/tears_of_steel/cleartext/stream.mpd">M(PEG)-DASH</option>
+                    <option value="https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps.mpd">M(PEG)-DASH</option>
                     <option value="https://www.dailymotion.com/video/x11prnt">DailyMotion</option>
                     <option value="https://www.youtube.com/watch?v=twYp6W6vt2U">YouTube</option>
                     <option value="https://player.vimeo.com/video/108018156?title=0&amp;byline=0&amp;portrait=0&amp;badge=0">Vimeo</option>
@@ -159,13 +169,45 @@
         <br>
         <hr>
 
+        <!-- VIDEOPLAYER - MPEG-Dash (Source is initially set, to find problems which only happen on load) -->
+        <div class="players" id="player-dash-container">
+            <h3>Video Player - MPEG-Dash</h3>
+
+            <p>Videoplayer which has mpeg-dash as the only source, so it gets loaded initially to find problems
+            that only happens on load.</p>
+
+            <div class="media-wrapper">
+                <video id="player-dash" width="640" height="360" style="max-width:100%;" poster="http://www.mediaelementjs.com/images/big_buck_bunny.jpg" preload="none" controls playsinline webkit-playsinline>
+                    <source src="https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps.mpd" type="application/dash+xml">
+                    <track srclang="de" kind="subtitles" src="german.vtt" label="German with lines">
+                    <track srclang="en" kind="subtitles" src="english.vtt" default>
+                    <track srclang="en" kind="chapters" src="english_chapters.vtt">
+                    <track srclang="de" kind="chapters" src="german_chapters.vtt">
+                </video>
+            </div>
+            <div class="player-info">
+                <h4>Player information</h4>
+                <div id="player-dash-rendername">
+                    <p><strong>Source</strong>: <span class="src"><a href="https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps.mpd" target="_blank">https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps.mpd</a></span></p>
+                    <p><strong>Renderer</strong>: <span class="renderer">html5</span></p>
+                    <p class="error"></p>
+                </div>
+            </div>
+        </div>
+
+        <br>
+        <hr>
+
+        <!-- AUDIOPLAYER -->
         <div class="players" id="player2-container">
 
             <h3>Audio Player</h3>
 
             <p>By default, time handle element is hidden, but in this demo the following styles were added to display it just for audio:</p>
 
-            <pre><code>
+            <details class="details">
+                <summary style="cursor:pointer">CSS-Code</summary>
+                <pre><code>
 #player2-container .mejs__time-buffering,
 #player2-container .mejs__time-current,
 #player2-container .mejs__time-handle,
@@ -199,6 +241,7 @@
     height: 0.75rem;
 }
             </code></pre>
+            </details>
 
             <div class="media-wrapper">
                 <audio id="player2" preload="none" controls style="max-width:100%;">
@@ -211,9 +254,7 @@
                     <option value="https://github.com/mediaelement/mediaelement-files/blob/master/AirReview-Landmarks-02-ChasingCorporate.mp3?raw=true">MP3</option>
                     <option value="https://commons.wikimedia.org/wiki/File:Demo_chorus.ogg">OGG</option>
                     <option value="http://db3.indexcom.com/bucket/ram/00/05/64k/05.m3u8">HLS</option>
-                    <!--<option value="rtmp://s3b78u0kbtx79q.cloudfront.net/cfx/st/mp3:fake_empire-cbr">RTMP</option>-->
                     <option value="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/282715465&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false&amp;visual=true">SoundCloud</option>
-                    <!--<option value="https://api.soundcloud.com/tracks/323195515/stream?client_id=95f22ed54a5c297b1c41f72d713623ef">SoundCloud</option>-->
                 </select>
                 </label>
             </div>

--- a/src/js/features/tracks.js
+++ b/src/js/features/tracks.js
@@ -334,7 +334,7 @@ Object.assign(MediaElementPlayer.prototype, {
    */
   handleCaptionsLoaded(target) {
     const
-      textTracks = this.domNode.textTracks,
+      textTracks = this.node.textTracks,
       playerTrack = this.getTrackById(target.getAttribute('id'));
 
     // Set default cue line
@@ -490,10 +490,10 @@ Object.assign(MediaElementPlayer.prototype, {
    * Set mode for all tracks to 'hidden' (causes player to load them).
    */
   hideAllTracks() {
-    if (this.domNode.textTracks) {
+    if (this.node.textTracks) {
       // parse through TextTrackList (not an Array)
-      for (let i = 0; i < this.domNode.textTracks.length; i++) {
-        this.domNode.textTracks[i].mode = 'hidden';
+      for (let i = 0; i < this.node.textTracks.length; i++) {
+        this.node.textTracks[i].mode = 'hidden';
       }
     }
   },
@@ -502,10 +502,10 @@ Object.assign(MediaElementPlayer.prototype, {
    * Hide all subtitles/captions.
    */
   deactivateVideoTracks() {
-    if (this.domNode.textTracks) {
+    if (this.node.textTracks) {
       // parse through TextTrackList (not an Array)
-      for (let i = 0; i < this.domNode.textTracks.length; i++) {
-        const track = this.domNode.textTracks[i];
+      for (let i = 0; i < this.node.textTracks.length; i++) {
+        const track = this.node.textTracks[i];
         if (track.kind === 'subtitles' || track.kind === 'captions') {
           track.mode = 'hidden';
         }
@@ -523,8 +523,8 @@ Object.assign(MediaElementPlayer.prototype, {
    */
   activateVideoTrack(srclang) {
     // parse through TextTrackList (not an Array)
-    for (let i = 0; i < this.domNode.textTracks.length; i++) {
-      const track = this.domNode.textTracks[i];
+    for (let i = 0; i < this.node.textTracks.length; i++) {
+      const track = this.node.textTracks[i];
       // For the 'subtitles-off' button, the first condition will never match so all will subtitles be turned off
       if (track.kind === 'subtitles' || track.kind === 'captions') {
         if (track.language === srclang) {
@@ -641,7 +641,7 @@ Object.assign(MediaElementPlayer.prototype, {
   drawChapters (chapterTrackId) {
     const
       t = this,
-      chapter = this.domNode.textTracks.getTrackById(chapterTrackId),
+      chapter = this.node.textTracks.getTrackById(chapterTrackId),
       numberOfChapters = chapter.cues.length
     ;
 

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -245,6 +245,9 @@ class MediaElementPlayer {
 		t.mediaFiles = null;
 		t.trackFiles = null;
 
+		// We need to set the listener early, or it doesn't get called when a renderer is created on load.
+		t.media.addEventListener('rendererready', this.updateNode.bind(this))
+
 		// use native controls in iPad, iPhone, and Android
 		if ((IS_IPAD && t.options.iPadUseNativeControls) || (IS_IPHONE && t.options.iPhoneUseNativeControls)) {
 
@@ -401,8 +404,6 @@ class MediaElementPlayer {
 			const event = createEvent('controlsshown', t.getElement(t.container));
 			t.getElement(t.container).dispatchEvent(event);
 		}
-
-		t.media.addEventListener('rendererready', this.updateNode.bind(this))
 	}
 
 	/**
@@ -416,7 +417,7 @@ class MediaElementPlayer {
 	 */
 	updateNode(event) {
 		let node, iframeId;
-		const mediaElement = event.detail.target.mediaElement;
+		const mediaElement = event.detail.target.hasOwnProperty('mediaElement') ? event.detail.target.mediaElement : event.detail.target;
 		const originalNode = mediaElement.originalNode;
 
 		if (event.detail.isIframe) {

--- a/src/js/renderers/dash.js
+++ b/src/js/renderers/dash.js
@@ -261,7 +261,7 @@ const DashNativeRenderer = {
 		};
 
 		const event = createEvent('rendererready', node, false);
-		mediaElement.dispatchEvent(event);
+		mediaElement.originalNode.dispatchEvent(event);
 
 		mediaElement.promises.push(NativeDash.load({
 			options: options.dash,

--- a/src/js/renderers/hls.js
+++ b/src/js/renderers/hls.js
@@ -294,7 +294,7 @@ const HlsNativeRenderer = {
 		};
 
 		const event = createEvent('rendererready', node, false);
-		mediaElement.dispatchEvent(event);
+		mediaElement.originalNode.dispatchEvent(event);
 
 		mediaElement.promises.push(NativeHls.load({
 			options: options.hls,

--- a/src/js/renderers/html5.js
+++ b/src/js/renderers/html5.js
@@ -150,7 +150,7 @@ const HtmlMediaElement = {
 		});
 
 		const event = createEvent('rendererready', node, false);
-		mediaElement.dispatchEvent(event);
+		mediaElement.originalNode.dispatchEvent(event);
 
 		return node;
 	}


### PR DESCRIPTION
Trying to fix the problems with captions, that sometimes they are not working correctly with multiple problems. Tracks feature now uses `node`, instead of `domNode`. MPEG-Dash, HLS and HTML renderer now dispatches event to the originalNode. `rendererready`-Eventlistener is now set early to catch early events from creating renderers. It's hard to find out, when `node` should be used and when `domNode` is correct. Maybe refactor in the future to reduce only to one node.