### PR TITLE
Improve performance by eliminating the SUPPORT_POINTER_EVENTS test logic

### DIFF
--- a/src/js/utils/constants.js
+++ b/src/js/utils/constants.js
@@ -18,24 +18,7 @@ export const IS_FIREFOX = /firefox/i.test(UA);
 export const IS_SAFARI = /safari/i.test(UA) && !IS_CHROME;
 export const IS_STOCK_ANDROID = /^mozilla\/\d+\.\d+\s\(linux;\su;/i.test(UA);
 export const HAS_MSE = ('MediaSource' in window);
-export const SUPPORT_POINTER_EVENTS = (() => {
-	const
-		element = document.createElement('x'),
-		documentElement = document.documentElement,
-		getComputedStyle = window.getComputedStyle
-	;
-
-	if (!('pointerEvents' in element.style)) {
-		return false;
-	}
-
-	element.style.pointerEvents = 'auto';
-	element.style.pointerEvents = 'x';
-	documentElement.appendChild(element);
-	let supports = getComputedStyle && (getComputedStyle(element, '') || {}).pointerEvents === 'auto';
-	element.remove();
-	return !!supports;
-})();
+export const SUPPORT_POINTER_EVENTS = true; // Now supported by all browsers even IE11 (>98% of all global users), so no need to test anymore: https://caniuse.com/pointer-events
 
 // Test via a getter in the options object to see if the passive property is accessed
 export const SUPPORT_PASSIVE_EVENT = (() => {


### PR DESCRIPTION
In doing a performance analysis of a WordPress site, I noticed that `mediaelement-and-player.js` was contributing to a long task due to the [logic](https://github.com/mediaelement/mediaelement/blob/4f886e35a61b1c2e47ef2f31bf834f808fa9f5cd/src/js/utils/constants.js#L21-L39) to compute the value of `SUPPORT_POINTER_EVENTS`:

https://github.com/mediaelement/mediaelement/blob/4f886e35a61b1c2e47ef2f31bf834f808fa9f5cd/src/js/utils/constants.js#L21-L39

Specifically, the code is causing a style recalculation. The function above is highlighted in the following flame graph:

![image](https://github.com/mediaelement/mediaelement/assets/134745/cc1cd45f-852d-4f2a-afe1-172dddb16daa)

 It seems however that this entire test can be eliminated as it is obsolete. It has been present in the codebase for many years, and browsers have improved a lot since then. In fact, the `pointer-events` property is now [supported](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events#browser_compatibility) by all browsers, _including_ IE11, which are used by [>98% of all users globally](https://caniuse.com/pointer-events). 

I created a simple [A/B test](https://mejs-pointer-events-test-perf.glitch.me/) to compare the performance with the logic present and removed.

When running the two versions through my team's [`benchmark-web-vitals`](https://github.com/GoogleChromeLabs/wpp-research/tree/main/cli#benchmark-web-vitals) tool with emulating a 6x CPU slowdown, I see significant improvement to LCP given that the script is not blocking the loading of the page. (I ran these tests on `localhost` instead of loading from Glitch.) 

# Before

```
npm run research -- benchmark-web-vitals --url https://mejs-pointer-events-test-perf.glitch.me/original.html --number 50 --throttle-cpu 6
```

Metric | Value
--|--:
FCP (median) | 412.8
LCP (median) | 412.8
TTFB (median) | 7.25
LCP-TTFB (median) | 397.65

Example trace: https://trace.cafe/t/QJKy0EHqBg

# After

```bash
npm run research -- benchmark-web-vitals --url https://mejs-pointer-events-test-perf.glitch.me/patched.html --number 50 --throttle-cpu 6
```

Metric | Value
--|--:
FCP (median) | 379.7 
LCP (median) | 379.7
TTFB (median) | 8.4
LCP-TTFB (median) | 364.9

Example trace: https://trace.cafe/t/qaW9JYhKo3

# Result

By removing the `pointer-events` tests, the test page loads 8.24% faster and saves 32.75 ms off the Largest Contentful Paint metric (ignoring differences in TTFB).

Note that I [found](https://gist.github.com/westonruter/0cc169156302d3012f1cfdfb06ab32fc) that MediaElement.js is present on 4.7% of all WordPress pages in HTTP Archive. Given that WordPress is the most popular CMS on the web, improving performance of ME.js here will make a dent in web performance as a whole.