### PR TITLE
Fixed wrong focus on load

### DIFF
--- a/src/js/features/tracks.js
+++ b/src/js/features/tracks.js
@@ -147,13 +147,12 @@ Object.assign(MediaElementPlayer.prototype, {
     // if only one language then just make the button a toggle
     if (t.options.toggleCaptionsButtonWhenOnlyOne && subtitles.length === 1) {
       player.captionsButton.classList.add(`${t.options.classPrefix}captions-button-toggle`);
-      player.captionsButton.addEventListener('click', (e) => {
+      player.captionsButton.addEventListener('click', () => {
         let trackId = 'none';
         if (player.selectedTrack === null) {
           trackId = player.getSubtitles()[0].trackId;
         }
-        const keyboard = e.keyCode || e.which;
-        player.setTrack(trackId, (typeof keyboard !== 'undefined'));
+        player.setTrack(trackId);
       });
     } else {
       const
@@ -436,9 +435,8 @@ Object.assign(MediaElementPlayer.prototype, {
   /**
    *
    * @param {String} trackId, or "none" to disable captions
-   * @param {Boolean} setByKeyboard
    */
-  setTrack (trackId, setByKeyboard) {
+  setTrack (trackId) {
     const
       t = this,
       radios = t.captionsButton.querySelectorAll('input[type="radio"]'),
@@ -478,12 +476,6 @@ Object.assign(MediaElementPlayer.prototype, {
     const event = createEvent('captionschange', t.media);
     event.detail.caption = t.selectedTrack;
     t.media.dispatchEvent(event);
-
-    if (!setByKeyboard) {
-      setTimeout(function() {
-        t.getElement(t.container).focus();
-      }, 500);
-    }
   },
 
   /**
@@ -558,9 +550,7 @@ Object.assign(MediaElementPlayer.prototype, {
         const target = document.getElementById(`${autoplayTrack.trackId}-btn`)
         if (target) {
           target.checked = true;
-          const clickEvent = createEvent('click', target);
-          clickEvent.stopPropagation();
-          target.dispatchEvent(clickEvent);
+          target.dispatchEvent(createEvent('click', target));
         }
       }
     }

--- a/src/js/features/tracks.js
+++ b/src/js/features/tracks.js
@@ -180,9 +180,8 @@ Object.assign(MediaElementPlayer.prototype, {
           // value is trackId, same as the actual id, and we're using it here
           // because the "none" checkbox doesn't have a trackId
           // to use, but we want to know when "none" is clicked
-          const keyboard = e.keyCode || e.which;
           if (!e.target.disabled) {
-            player.setTrack(this.value, (typeof keyboard !== 'undefined'));
+            player.setTrack(this.value);
           }
         });
       }


### PR DESCRIPTION
When a player witch captions is loaded, it gets a focus from the start. This was caused by `setByKeyboard`-Attribute inside the `setTrack`-Function. Fixed it by removing `setByKeyboard` and the corresponding parameters inside the `setTrack`-Function.