### PR TITLE
fix: svg4everyone remove define variable for umd header (fixes #2968)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -107,6 +107,13 @@ module.exports = function (grunt) {
 					'build/renderers/vimeo.js': 'src/js/renderers/vimeo.js'
 				},
 				options: {
+					browserifyOptions: {
+						insertGlobalVars: {
+							"define": function() {
+								return 'null';
+							}
+						}
+					},
 					plugin: [
 						'browserify-derequire', 'bundle-collapser/plugin'
 					]


### PR DESCRIPTION
fixes #2968 

### Fix
* Replaces the `define` variable in the `svg4everyone` module with `null` such that the `amd` section of the `umd` header is nullified and the module loads normally.