### PR TITLE
fix: Fixed zero player height after initialization

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -1115,7 +1115,7 @@ class MediaElementPlayer {
 
 		if (t.isVideo) {
 			// Responsive video is based on width: 100% and height: 100%
-			if (t.height === '100%' && t.width === '100%') {
+			if (t.height === '100%' && t.width === '100%' && parentHeight > 0) {
 				newHeight = parentHeight;
 			}
 			else if (t.height === '100%') {


### PR DESCRIPTION
Changed behavior to state before 7.0.2 when parentHeight is 0 to prevent that the player height is 0 after initialization