### PR TITLE
Added check that target.closest is a function in mousemov.vol code

### DIFF
--- a/src/js/features/volume.js
+++ b/src/js/features/volume.js
@@ -392,7 +392,6 @@ Object.assign(MediaElementPlayer.prototype, {
 			handleVolumeMove(e);
 			t.globalBind('mousemove.vol', (event) => {
 				const target = event.target;
-				// check for `closest` fixes firefox error: https://github.com/mediaelement/mediaelement/pull/2840/files
 				const targetHasClosest = typeof target.closest == 'function';
 				const targetSliderElement = targetHasClosest && target.closest(
 					(mode === 'vertical' ? `.${t.options.classPrefix}volume-slider` : `.${t.options.classPrefix}horizontal-volume-slider`)


### PR DESCRIPTION
This is a similar fix to #2840
This prevents a crash on Firefox