### PR TITLE
Add keyboard controls for play and pause to container element

### DIFF
--- a/src/js/features/progress.js
+++ b/src/js/features/progress.js
@@ -4,7 +4,7 @@ import document from 'global/document';
 import {config} from '../player';
 import MediaElementPlayer from '../player';
 import i18n from '../core/i18n';
-import {IS_FIREFOX, IS_IOS, IS_ANDROID, SUPPORT_PASSIVE_EVENT} from '../utils/constants';
+import {IS_IOS, IS_ANDROID, SUPPORT_PASSIVE_EVENT} from '../utils/constants';
 import {secondsToTimeCode} from '../utils/time';
 import {offset, addClass, removeClass, hasClass} from '../utils/dom';
 
@@ -93,7 +93,7 @@ Object.assign(MediaElementPlayer.prototype, {
 
 					// 5%
 					const newTime = Math.max(player.currentTime - player.options.defaultSeekBackwardInterval(player), 0);
-					
+
 					// pause to track current time
 					if (!player.paused) {
 						player.pause();
@@ -131,7 +131,7 @@ Object.assign(MediaElementPlayer.prototype, {
 
 					// 5%
 					const newTime = Math.min(player.currentTime + player.options.defaultSeekForwardInterval(player), player.duration);
-					
+
 					// pause to track current time
 					if (!player.paused) {
 						player.pause();
@@ -413,13 +413,10 @@ Object.assign(MediaElementPlayer.prototype, {
 						seekTime = duration;
 						break;
 					case 13: // enter
-					case 32: // space
-						if (IS_FIREFOX) {
-							if (t.paused) {
-								t.play();
-							} else {
-								t.pause();
-							}
+						if (t.paused) {
+							t.play();
+						} else {
+							t.pause();
 						}
 						return;
 					default:

--- a/src/js/player.js
+++ b/src/js/player.js
@@ -853,6 +853,20 @@ class MediaElementPlayer {
 				}
 			});
 
+			if (t.options.enableKeyboard) {
+				t.getElement(t.container).addEventListener('keydown', function (e) {
+					const keyCode = e.keyCode || e.which || 0;
+					// On Enter, play media
+					if (e.target === t.container && keyCode === 13) {
+						if (t.paused) {
+							t.play();
+						} else {
+							t.pause();
+						}
+					}
+				})
+			}
+
 			// Disable focus outline to improve look-and-feel for regular users
 			t.getElement(t.container).addEventListener('click', function (e) {
 				dom.addClass(e.currentTarget, `${t.options.classPrefix}container-keyboard-inactive`);
@@ -1607,16 +1621,6 @@ class MediaElementPlayer {
 
 				button.setAttribute('aria-pressed', !!pressed);
 				t.getElement(t.container).focus();
-			}
-		});
-		// Allow keyboard to execute action on play button
-		bigPlay.addEventListener('keydown', function (e) {
-			const keyPressed = e.keyCode || e.which || 0;
-			// On Enter, play media
-			if (keyPressed === 13 || (IS_FIREFOX && keyPressed === 32)) {
-				const event = createEvent('click', bigPlay);
-				bigPlay.dispatchEvent(event);
-				return false;
 			}
 		});
 


### PR DESCRIPTION
This PR adds play/pause functionality to the `mejs__container` element. It already could receive keyboard focus with `tabindex="0"` and had `aria-label="Audioplayer"`, so keyboard users should be able to play and pause it with keyboard.

The default browser behaviour of the Space key (which scrolls the page down a bit) is preserved in this PR.

- Add play/pause with Enter key (keyCode 13) to `mejs__container`
- Remove `keydown` Event for "big play button", because it was redundant. Pressing enter or space on the button would already trigger the button click event.
- Update behaviour for the Enter key on the progress bar. Until now it would only play and pause the video only in Firefox (for whatever reason) and now it does that in all browsers. The Space key on the progress bar now has default browser behaviour (scrolling the page).