### PR TITLE
issue-2970-firefox-issue-with-cancelFullscreen

### DIFF
--- a/src/js/utils/constants.js
+++ b/src/js/utils/constants.js
@@ -112,6 +112,7 @@ if (hasTrueNativeFullScreen) {
 	};
 
 	cancelFullScreen = () => {
+		if (!isFullScreen()) return;
 		if (hasWebkitNativeFullScreen) {
 			document.webkitCancelFullScreen();
 


### PR DESCRIPTION
To reoslve the issue of `Uncaught (in promise) TypeError: Not in fullscreen mode` error.