### PR TITLE
Localized duration for screenreaders (fixes issues #2908 and #2935)

### DIFF
--- a/src/js/features/progress.js
+++ b/src/js/features/progress.js
@@ -5,7 +5,7 @@ import {config} from '../player';
 import MediaElementPlayer from '../player';
 import i18n from '../core/i18n';
 import {IS_IOS, IS_ANDROID, SUPPORT_PASSIVE_EVENT} from '../utils/constants';
-import {secondsToTimeCode} from '../utils/time';
+import {framesToLocalizedDuration, secondsToTimeCode} from '../utils/time';
 import {offset, addClass, removeClass, hasClass} from '../utils/dom';
 
 /**
@@ -305,7 +305,7 @@ Object.assign(MediaElementPlayer.prototype, {
 				const
 					seconds = t.getCurrentTime(),
 					timeSliderText = i18n.t('mejs.time-slider'),
-					time = secondsToTimeCode(seconds, player.options.alwaysShowHours, player.options.showTimecodeFrameCount, player.options.framesPerSecond, player.options.secondsDecimalLength, player.options.timeFormat),
+					textCurrentTime = framesToLocalizedDuration(seconds, player.options.showTimecodeFrameCount, player.options.framesPerSecond),
 					duration = t.getDuration()
 				;
 
@@ -316,7 +316,7 @@ Object.assign(MediaElementPlayer.prototype, {
 				t.slider.setAttribute('aria-valuemin', 0);
 				t.slider.setAttribute('aria-valuemax', isNaN(duration) ? 0 : duration);
 				t.slider.setAttribute('aria-valuenow', seconds);
-				t.slider.setAttribute('aria-valuetext', time);
+				t.slider.setAttribute('aria-valuetext', textCurrentTime);
 			},
 			/**
 			 *

--- a/src/js/features/progress.js
+++ b/src/js/features/progress.js
@@ -312,19 +312,11 @@ Object.assign(MediaElementPlayer.prototype, {
 				t.slider.setAttribute('role', 'slider');
 				t.slider.tabIndex = 0;
 
-				if (media.paused) {
-					t.slider.setAttribute('aria-label', timeSliderText);
-					t.slider.setAttribute('aria-valuemin', 0);
-					t.slider.setAttribute('aria-valuemax', isNaN(duration) ? 0 : duration);
-					t.slider.setAttribute('aria-valuenow', seconds);
-					t.slider.setAttribute('aria-valuetext', time);
-				} else {
-					t.slider.removeAttribute('aria-label');
-					t.slider.removeAttribute('aria-valuemin');
-					t.slider.removeAttribute('aria-valuemax');
-					t.slider.removeAttribute('aria-valuenow');
-					t.slider.removeAttribute('aria-valuetext');
-				}
+				t.slider.setAttribute('aria-label', timeSliderText);
+				t.slider.setAttribute('aria-valuemin', 0);
+				t.slider.setAttribute('aria-valuemax', isNaN(duration) ? 0 : duration);
+				t.slider.setAttribute('aria-valuenow', seconds);
+				t.slider.setAttribute('aria-valuetext', time);
 			},
 			/**
 			 *

--- a/src/js/languages/de.js
+++ b/src/js/languages/de.js
@@ -34,6 +34,10 @@
 			// features/time.js
 			'mejs.current': 'Aktueller Zeitpunkt',
 			'mejs.duration': 'Gesamtlaufzeit',
+			'mejs.hours': ['1 Stunde', '%1 Stunden'],
+			'mejs.minutes': ['1 Minute', '%1 Minuten'],
+			'mejs.seconds': ['1 Sekunde', '%1 Sekunden'],
+			'mejs.frames': ['1 Frame', '%1 Frames'],
 
 			// features/volume.js
 			'mejs.volume-help-text': 'Verwende die Pfeiltaste nach oben/nach unten um die Lautstärke zu erhöhen oder zu verringern.',

--- a/src/js/languages/en.js
+++ b/src/js/languages/en.js
@@ -32,6 +32,10 @@ export const EN = {
 	// features/time.js
 	'mejs.current': 'Current time',
 	'mejs.duration': 'Total duration',
+	'mejs.hours': ['1 hour', '%1 hours'],
+	'mejs.minutes': ['1 minute', '%1 minutes'],
+	'mejs.seconds': ['1 second', '%1 seconds'],
+	'mejs.frames': ['1 frame', '%1 frames'],
 
 	// features/volume.js
 	'mejs.volume-help-text': 'Use Up/Down Arrow keys to increase or decrease volume.',

--- a/src/js/utils/time.js
+++ b/src/js/utils/time.js
@@ -173,26 +173,27 @@ export function framesToLocalizedDuration(time, showFrameCount = false, fps = 25
 	seconds = seconds === 60 ? 0 : seconds;
 	minutes = minutes === 60 ? 0 : minutes;
 
-	let result = '';
+	let resultList = [];
 
 	if (hours > 0) {
-		result += `${i18n.t('mejs.hours', hours)} `;
+		resultList.push(i18n.t('mejs.hours', hours));
 	}
 
 	if (hours > 0 || minutes > 0) {
-		result += `${i18n.t('mejs.minutes', minutes)} `;
+		resultList.push(i18n.t('mejs.minutes', minutes));
 	}
 
-	result += `${i18n.t('mejs.seconds', seconds)}`;
+	resultList.push(i18n.t('mejs.seconds', seconds));
 
 	if (showFrameCount) {
 		frames = Math.round(f % timeBase);
 		frames = frames <= 0 ? 0 : frames;
 
-		result += ` ${i18n.t('mejs.frames', frames)}`
+		resultList.push(i18n.t('mejs.frames', frames));
 	}
 
-	return result;
+	const formatter = new Intl.ListFormat(i18n.lang, { style: 'long', type: 'unit' });
+	return formatter.format(resultList);
 }
 
 /**

--- a/src/js/utils/time.js
+++ b/src/js/utils/time.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import mejs from '../core/mejs';
+import i18n from "../core/i18n";
 
 /**
  * Indicate if FPS is dropFrame (typically non-integer frame rates: 29.976)
@@ -64,8 +65,7 @@ export function secondsToTimeCode(time, forceHours = false, showFrameCount = fal
 		} else {
 			seconds = Math.floor((f / timeBase) % 60).toFixed(secondsDecimalLength);
 		}
-	}
-	else {
+	} else {
 		hours = Math.floor(time / 3600) % 24;
 		minutes = Math.floor(time / 60) % 60;
 		if (showFrameCount) {
@@ -109,17 +109,14 @@ export function secondsToTimeCode(time, forceHours = false, showFrameCount = fal
 }
 
 /**
- * Format a numeric time in format '00:00:00'
+ * Format a numeric time into localized hours, minutes, seconds
  *
  * @param {Number} time - Ideally a number, but if not or less than zero, is defaulted to zero
- * @param {Boolean} forceHours
  * @param {Boolean} showFrameCount
  * @param {Number} fps - Frames per second
- * @param {Number} secondsDecimalLength - Number of decimals to display if any
- * @param {String} timeFormat
  * @return {String}
  */
-export function framesToLocalizedDuration(time, forceHours = false, showFrameCount = false, fps = 25, secondsDecimalLength = 0, timeFormat = 'hh:mm:ss') {
+export function framesToLocalizedDuration(time, showFrameCount = false, fps = 25) {
 
 	time = !time || typeof time !== 'number' || time < 0 ? 0 : time;
 
@@ -128,7 +125,6 @@ export function framesToLocalizedDuration(time, forceHours = false, showFrameCou
 		timeBase = Math.round(fps),
 		framesPer24Hours = Math.round(fps * 3600) * 24,
 		framesPer10Minutes = Math.round(fps * 600),
-		frameSep = isDropFrame(fps) ? ';' : ':',
 		hours,
 		minutes,
 		seconds,
@@ -159,16 +155,15 @@ export function framesToLocalizedDuration(time, forceHours = false, showFrameCou
 		if (showFrameCount) {
 			seconds = timeBaseDivision % 60;
 		} else {
-			seconds = Math.floor((f / timeBase) % 60).toFixed(secondsDecimalLength);
+			seconds = Math.floor((f / timeBase) % 60);
 		}
-	}
-	else {
+	} else {
 		hours = Math.floor(time / 3600) % 24;
 		minutes = Math.floor(time / 60) % 60;
 		if (showFrameCount) {
 			seconds = Math.floor(time % 60);
 		} else {
-			seconds = Math.floor(time % 60).toFixed(secondsDecimalLength);
+			seconds = Math.floor(time % 60);
 		}
 	}
 	hours = hours <= 0 ? 0 : hours;
@@ -178,28 +173,23 @@ export function framesToLocalizedDuration(time, forceHours = false, showFrameCou
 	seconds = seconds === 60 ? 0 : seconds;
 	minutes = minutes === 60 ? 0 : minutes;
 
-	const timeFormatFrags = timeFormat.split(':');
-	const timeFormatSettings = {};
-	for (let i = 0, total = timeFormatFrags.length; i < total; ++i) {
-		let unique = '';
-		for (let j = 0, t = timeFormatFrags[i].length; j < t; j++) {
-			if (unique.indexOf(timeFormatFrags[i][j]) < 0) {
-				unique += timeFormatFrags[i][j];
-			}
-		}
-		if (~['f', 's', 'm', 'h'].indexOf(unique)) {
-			timeFormatSettings[unique] = timeFormatFrags[i].length;
-		}
+	let result = '';
+
+	if (hours > 0) {
+		result += `${i18n.t('mejs.hours', hours)} `;
 	}
 
-	let result = (forceHours || hours > 0) ? `${(hours < 10 && timeFormatSettings.h > 1 ? `0${hours}` : hours)}:` : '';
-	result += `${(minutes < 10 && timeFormatSettings.m > 1 ? `0${minutes}` : minutes)}:`;
-	result += `${(seconds < 10 && timeFormatSettings.s > 1 ? `0${seconds}` : seconds)}`;
+	if (hours > 0 || minutes > 0) {
+		result += `${i18n.t('mejs.minutes', minutes)} `;
+	}
+
+	result += `${i18n.t('mejs.seconds', seconds)}`;
 
 	if (showFrameCount) {
-		frames = (f % timeBase).toFixed(0);
+		frames = Math.round(f % timeBase);
 		frames = frames <= 0 ? 0 : frames;
-		result += (frames < 10 && timeFormatSettings.f) ? `${frameSep}0${frames}` : `${frameSep}${frames}`;
+
+		result += ` ${i18n.t('mejs.frames', frames)}`
 	}
 
 	return result;


### PR DESCRIPTION
Fixes issues #2908 and #2935.

Includes 4 new labels for hours, minutes, seconds and frames. Only English and German are included. An alternative implementation using Intl.DurationFormat is currently impractical since [Intl.DurationFormat isn't well-supported by Firefox](https://caniuse.com/?search=Intl.DurationFormat), or at least the extended support releases (currently 128 in March 2025).

The last commit regarding Intl.ListFormat probably isn't strictly necessary and could be dropped for compatibility, but [Intl.ListFormat is well-supported](https://caniuse.com/?search=Intl.ListFormat).