### PR TITLE
fix #2993 : iterate properly in sources array in case of multiple sources

### DIFF
--- a/src/js/renderers/hls.js
+++ b/src/js/renderers/hls.js
@@ -207,7 +207,7 @@ const HlsNativeRenderer = {
 							case 'networkError':
 								if (data.details === 'manifestLoadError') {
 									if (index < total && mediaFiles[(index + 1)] !== undefined) {
-										node.setSrc(mediaFiles[index++].src);
+										node.setSrc(mediaFiles[++index].src);
 										node.load();
 										node.play();
 									} else {

--- a/src/js/renderers/html5.js
+++ b/src/js/renderers/html5.js
@@ -140,7 +140,7 @@ const HtmlMediaElement = {
 			// Reload the source only in case of the renderer is active at the moment
 			if (e && e.target && e.target.error && e.target.error.code === 4 && isActive) {
 				if (index < total && mediaFiles[(index + 1)] !== undefined) {
-					node.src = mediaFiles[index++].src;
+					node.src = mediaFiles[++index].src;
 					node.load();
 					node.play();
 				} else {


### PR DESCRIPTION
increment index before using it to get the next source in case of error of the previous one, otherwise the first source is tried twice and the last source is never tried

Refs: https://github.com/mediaelement/mediaelement/issues/2993