### PR TITLE
Fix: Replace JSDocs link with valid web site

### DIFF
--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -19,7 +19,7 @@
 * Tab size is **8** for indentation.
 * **ALWAYS** make changes to the files in the `/src/` directory, and **NEVER** in `/build/` directory. This is with the sole purpose of facilitating the merging (and further, the compiling) operation, and help people to see changes more easily.
 * Make sure you download the necessary media files from https://github.com/mediaelement/mediaelement-files and place them inside the `/media/` directory.
-* Use [JSDoc](http://usejsdoc.org/) conventions to document code. This facilitates the contributions of other developers and ensures more quality in the product.
+* Use [JSDoc](https://jsdoc.app/) conventions to document code. This facilitates the contributions of other developers and ensures more quality in the product.
 * If you would like to contribute with translations, make sure that you also check https://github.com/mediaelement/mediaelement-plugins, and perform the
  translations for the files suffixed as `-i18n`.
 


### PR DESCRIPTION
On the Guidelines for Contributors page, replace usejsdoc.org link with jsdoc.app as the former now redirects to a malicious gambling site.